### PR TITLE
[UKET-80] 어드민 전체 목록 페이징 조회 시, organizationName도 함께 전달

### DIFF
--- a/src/main/kotlin/api/admin/UserController.kt
+++ b/src/main/kotlin/api/admin/UserController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uket.api.admin.response.DeleteAdminResponse
 import uket.common.response.CustomPageResponse
-import uket.domain.admin.dto.AdminWithOrganizationIdAndName
+import uket.domain.admin.dto.AdminWithOrganizationDto
 import uket.domain.admin.service.AdminService
 
 @Tag(name = "어드민 멤버 관련 API", description = "어드민 멤버 관련 API 입니다.")
@@ -25,7 +25,7 @@ class UserController(
     @SecurityRequirement(name = "JWT")
     @Operation(summary = "어드민 멤버 목록 조회", description = "어드민 목록을 페이지로 조회합니다.")
     @GetMapping("/admin/users")
-    fun getAdmins(page: Int, size: Int): ResponseEntity<CustomPageResponse<AdminWithOrganizationIdAndName>> {
+    fun getAdmins(page: Int, size: Int): ResponseEntity<CustomPageResponse<AdminWithOrganizationDto>> {
         val pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         val adminPage = adminService.findAdminsWithOrganizationIdAndNameByPage(pageRequest)
         return ResponseEntity.ok(CustomPageResponse.from(adminPage))

--- a/src/main/kotlin/api/admin/UserController.kt
+++ b/src/main/kotlin/api/admin/UserController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import uket.api.admin.response.DeleteAdminResponse
 import uket.common.response.CustomPageResponse
-import uket.domain.admin.dto.AdminWithOrganizationIdDto
+import uket.domain.admin.dto.AdminWithOrganizationIdAndName
 import uket.domain.admin.service.AdminService
 
 @Tag(name = "어드민 멤버 관련 API", description = "어드민 멤버 관련 API 입니다.")
@@ -25,9 +25,9 @@ class UserController(
     @SecurityRequirement(name = "JWT")
     @Operation(summary = "어드민 멤버 목록 조회", description = "어드민 목록을 페이지로 조회합니다.")
     @GetMapping("/admin/users")
-    fun getAdmins(page: Int, size: Int): ResponseEntity<CustomPageResponse<AdminWithOrganizationIdDto>> {
+    fun getAdmins(page: Int, size: Int): ResponseEntity<CustomPageResponse<AdminWithOrganizationIdAndName>> {
         val pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
-        val adminPage = adminService.findAdminsWithOrganizationIdByPage(pageRequest)
+        val adminPage = adminService.findAdminsWithOrganizationIdAndNameByPage(pageRequest)
         return ResponseEntity.ok(CustomPageResponse.from(adminPage))
     }
 

--- a/src/main/kotlin/domain/admin/dto/AdminWithOrganizationDto.kt
+++ b/src/main/kotlin/domain/admin/dto/AdminWithOrganizationDto.kt
@@ -2,7 +2,7 @@ package uket.domain.admin.dto
 
 import uket.domain.admin.entity.Admin
 
-data class AdminWithOrganizationIdAndName(
+data class AdminWithOrganizationDto(
     val id: Long,
     val organizationId: Long,
     val organizationName: String,
@@ -12,7 +12,7 @@ data class AdminWithOrganizationIdAndName(
     val isSuperAdmin: Boolean,
 ) {
     companion object {
-        fun from(admin: Admin): AdminWithOrganizationIdAndName = AdminWithOrganizationIdAndName(
+        fun from(admin: Admin): AdminWithOrganizationDto = AdminWithOrganizationDto(
             id = admin.id,
             organizationId = admin.organization.id,
             organizationName = admin.organization.name,

--- a/src/main/kotlin/domain/admin/dto/AdminWithOrganizationIdAndName.kt
+++ b/src/main/kotlin/domain/admin/dto/AdminWithOrganizationIdAndName.kt
@@ -2,18 +2,20 @@ package uket.domain.admin.dto
 
 import uket.domain.admin.entity.Admin
 
-data class AdminWithOrganizationIdDto(
+data class AdminWithOrganizationIdAndName(
     val id: Long,
     val organizationId: Long,
+    val organizationName: String,
     val name: String,
     val email: String,
     var password: String?,
     val isSuperAdmin: Boolean,
 ) {
     companion object {
-        fun from(admin: Admin): AdminWithOrganizationIdDto = AdminWithOrganizationIdDto(
+        fun from(admin: Admin): AdminWithOrganizationIdAndName = AdminWithOrganizationIdAndName(
             id = admin.id,
             organizationId = admin.organization.id,
+            organizationName = admin.organization.name,
             name = admin.name,
             email = admin.email,
             password = admin.password,

--- a/src/main/kotlin/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/domain/admin/service/AdminService.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uket.domain.admin.dto.AdminWithOrganizationIdAndName
+import uket.domain.admin.dto.AdminWithOrganizationDto
 import uket.domain.admin.dto.RegisterAdminCommand
 import uket.domain.admin.dto.RegisterAdminWithoutPasswordCommand
 import uket.domain.admin.entity.Admin
@@ -27,12 +27,12 @@ class AdminService(
     fun getByEmail(email: String): Admin = adminRepository.findByEmail(email)
         ?: throw IllegalStateException("해당 어드민을 찾을 수 없습니다")
 
-    fun findAdminsWithOrganizationIdAndNameByPage(pageRequest: PageRequest): Page<AdminWithOrganizationIdAndName> {
+    fun findAdminsWithOrganizationIdAndNameByPage(pageRequest: PageRequest): Page<AdminWithOrganizationDto> {
         val ids = adminRepository.findAdminIds(pageRequest)
         val admins = adminRepository.findAllByIdsOrderByCreatedAtDesc(ids)
         val adminItems = admins
             .stream()
-            .map { AdminWithOrganizationIdAndName.from(it) }
+            .map { AdminWithOrganizationDto.from(it) }
             .toList()
         val count = adminRepository.count()
         return PageImpl(adminItems, pageRequest, count)

--- a/src/main/kotlin/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/domain/admin/service/AdminService.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uket.domain.admin.dto.AdminWithOrganizationIdDto
+import uket.domain.admin.dto.AdminWithOrganizationIdAndName
 import uket.domain.admin.dto.RegisterAdminCommand
 import uket.domain.admin.dto.RegisterAdminWithoutPasswordCommand
 import uket.domain.admin.entity.Admin
@@ -27,12 +27,12 @@ class AdminService(
     fun getByEmail(email: String): Admin = adminRepository.findByEmail(email)
         ?: throw IllegalStateException("해당 어드민을 찾을 수 없습니다")
 
-    fun findAdminsWithOrganizationIdByPage(pageRequest: PageRequest): Page<AdminWithOrganizationIdDto> {
+    fun findAdminsWithOrganizationIdAndNameByPage(pageRequest: PageRequest): Page<AdminWithOrganizationIdAndName> {
         val ids = adminRepository.findAdminIds(pageRequest)
         val admins = adminRepository.findAllByIdsOrderByCreatedAtDesc(ids)
         val adminItems = admins
             .stream()
-            .map { AdminWithOrganizationIdDto.from(it) }
+            .map { AdminWithOrganizationIdAndName.from(it) }
             .toList()
         val count = adminRepository.count()
         return PageImpl(adminItems, pageRequest, count)

--- a/src/main/kotlin/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/domain/admin/service/AdminService.kt
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uket.domain.admin.dto.AdminWithOrganizationIdDto
+import uket.domain.admin.dto.AdminWithOrganizationDto
 import uket.domain.admin.dto.RegisterAdminCommand
 import uket.domain.admin.entity.Admin
 import uket.domain.admin.entity.Organization

--- a/src/test/kotlin/uket/domain/admin/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uket/domain/admin/service/AdminServiceTest.kt
@@ -23,19 +23,27 @@ class AdminServiceTest :
         val adminRepository: AdminRepository = mockk<AdminRepository>()
         val adminService: AdminService = AdminService(adminRepository)
 
-        val organization: Organization = Organization(
+        val organization1: Organization = Organization(
+            id = 1L,
             name = "organizationA",
-            organizationImagePath = "imagePath",
+            organizationImagePath = "imagePathA",
+        )
+        val organization2: Organization = Organization(
+            id = 2L,
+            name = "organizationB",
+            organizationImagePath = "imagePathB",
         )
         val admin1: Admin = Admin(
-            organization = organization,
+            id = 1L,
+            organization = organization1,
             name = "adminA",
             email = "emailA",
             password = "passwordA",
             isSuperAdmin = false,
         )
         val admin2: Admin = Admin(
-            organization = organization,
+            id = 2L,
+            organization = organization2,
             name = "adminB",
             email = "emailB",
             password = "passwordB",
@@ -82,7 +90,7 @@ class AdminServiceTest :
             }
         }
 
-        describe("Admin 전체 조회") {
+        describe("Admin 전체 조회(페이징)") {
             val pageRequset = PageRequest.of(1, 2)
             context("Admin이 2개 이상이면") {
                 val list = listOf(admin1.id, admin2.id)
@@ -90,10 +98,18 @@ class AdminServiceTest :
                 every { adminRepository.findAllByIdsOrderByCreatedAtDesc(list) } returns listOf(admin2, admin1)
                 every { adminRepository.count() } returns 2
                 it("어드민 전체 목록을 반환한다") {
-                    val adminPage = adminService.findAdminsWithOrganizationIdByPage(pageRequset)
+                    val adminPage = adminService.findAdminsWithOrganizationIdAndNameByPage(pageRequset)
                     adminPage.content.size shouldBe 2
-                    adminPage.content.get(0).name shouldBe "adminB"
-                    adminPage.content.get(1).name shouldBe "adminA"
+
+                    val adminB = adminPage.content.get(0)
+                    adminB.organizationId shouldBe 2L
+                    adminB.name shouldBe "adminB"
+                    adminB.organizationName shouldBe "organizationB"
+
+                    val adminA = adminPage.content.get(1)
+                    adminA.organizationId shouldBe 1L
+                    adminA.name shouldBe "adminA"
+                    adminA.organizationName shouldBe "organizationA"
                 }
             }
             context("Admin이 1개면") {
@@ -102,7 +118,7 @@ class AdminServiceTest :
                 every { adminRepository.findAllByIdsOrderByCreatedAtDesc(list) } returns listOf(admin1)
                 every { adminRepository.count() } returns 1
                 it("어드민 전체 목록(이지만 1개)을 반환한다") {
-                    val adminPage = adminService.findAdminsWithOrganizationIdByPage(pageRequset)
+                    val adminPage = adminService.findAdminsWithOrganizationIdAndNameByPage(pageRequset)
                     adminPage.content.size shouldBe 1
                     adminPage.content.get(0).name shouldBe "adminA"
                 }
@@ -113,7 +129,7 @@ class AdminServiceTest :
                 every { adminRepository.findAllByIdsOrderByCreatedAtDesc(list) } returns listOf()
                 every { adminRepository.count() } returns 0
                 it("어드민 전체 목록(이지만 빈 리스트)을 반환한다") {
-                    val adminPage = adminService.findAdminsWithOrganizationIdByPage(pageRequset)
+                    val adminPage = adminService.findAdminsWithOrganizationIdAndNameByPage(pageRequset)
                     adminPage.content.size shouldBe 0
                 }
             }
@@ -121,7 +137,7 @@ class AdminServiceTest :
 
         describe("Admin 생성 요청") {
             val registerAdminCommand: RegisterAdminCommand = RegisterAdminCommand(
-                organization = organization,
+                organization = organization1,
                 name = "newAdmin",
                 email = "newEmail",
                 password = "newPassword",
@@ -155,7 +171,7 @@ class AdminServiceTest :
                 every { adminRepository.existsByEmail(registerAdminWithoutPasswordCommand.email) } returns false
                 every { adminRepository.save(any()) } returns admin1
                 it("Admin을 생성한다") {
-                    adminService.registerAdminWithoutPassword(registerAdminWithoutPasswordCommand, organization)
+                    adminService.registerAdminWithoutPassword(registerAdminWithoutPasswordCommand, organization1)
                     verify(exactly = 1) { adminRepository.save(any()) }
                 }
             }
@@ -166,7 +182,7 @@ class AdminServiceTest :
                         shouldThrow<IllegalStateException> {
                             adminService.registerAdminWithoutPassword(
                                 registerAdminWithoutPasswordCommand,
-                                organization,
+                                organization1,
                             )
                         }
                     exception.message shouldBe "이미 가입된 어드민입니다."


### PR DESCRIPTION
# 📌 개요
- 기존 어드민 전체 목록 조회 시, organization의 이름을 위해 organizationId로 한 번 더 요청을 해야했던 점을 수정했습니다
<img width="818" alt="image" src="https://github.com/user-attachments/assets/5a5e0164-57ef-48d8-9702-82bc2376ad44" />

# 💻 작업사항
- [x] AdminService.findAdminsWithOrganizationIdByPage()를 AdminService.findAdminsWithOrganizationIdAndNameByPage()로 수정
- [x] AdminWithOrganizationId를 AdminWithOrganizationIdAndName으로 수정
- [x] 어드민 전체 목록 페이징 조회 시, organizationName도 체크하도록 테스트 수정 

<details>
<summary>DDL 및 포스트맨 테스트</summary>
DDL

```
insert into organization(id, name, organization_image_path, created_at, updated_at) values(1, "organizationA", "imagePathA", CURRENT_TIME, CURRENT_TIME);
insert into admin(id, organization_id, name, email, password, is_super_admin, created_at, updated_at) values(1, 1, "adminA", "emailA", "passowordA", true, CURRENT_TIME, CURRENT_TIME);
insert into organization(id, name, organization_image_path, created_at, updated_at) values(2, "organizationB", "imagePathB", CURRENT_TIME, CURRENT_TIME);
insert into admin(id, organization_id, name, email, password, is_super_admin, created_at, updated_at) values(2, 2, "adminB", "emailB", "passowordB", false, CURRENT_TIME, CURRENT_TIME);
```

Login 및 Authorization 토큰 설정 이후
![image](https://github.com/user-attachments/assets/7f4f889b-8e00-4755-ba1a-92afb164aafc)
</details>

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
