### PR TITLE
[UKET-81] 어드민 메일 발송 API 수정

### DIFF
--- a/src/main/kotlin/api/admin/AdminController.kt
+++ b/src/main/kotlin/api/admin/AdminController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import uket.api.admin.request.EmailLoginRequest
 import uket.api.admin.request.RegisterAdminPasswordCommand
+import uket.api.admin.request.SendEmailRequest
 import uket.api.admin.response.RegisterAdminResponse
 import uket.api.admin.response.SendEmailResponse
 import uket.auth.dto.AdminAuthToken
@@ -29,9 +30,9 @@ class AdminController(
     @Operation(summary = "어드민 멤버 등록 메일 발송", description = "비밀번호를 제외한 어드민 멤버를 등록 후 회원가입 메일을 발송합니다.")
     @PostMapping("/register")
     fun sendInviteEmail(
-        @RequestBody registerAdminWithoutPasswordCommand: RegisterAdminWithoutPasswordCommand,
+        @RequestBody sendEmailRequest: SendEmailRequest,
     ): ResponseEntity<SendEmailResponse> {
-        val response: SendEmailResponse = adminAuthEmailFacade.sendAuthEmail(registerAdminWithoutPasswordCommand)
+        val response: SendEmailResponse = adminAuthEmailFacade.sendAuthEmail(sendEmailRequest)
         return ResponseEntity.ok(response)
     }
 

--- a/src/main/kotlin/api/admin/request/SendEmailRequest.kt
+++ b/src/main/kotlin/api/admin/request/SendEmailRequest.kt
@@ -1,0 +1,8 @@
+package uket.api.admin.request
+
+data class SendEmailRequest(
+    val name: String,
+    val email: String,
+    val organization: String,
+    val authority: String,
+)

--- a/src/main/kotlin/auth/dto/AdminAuthToken.kt
+++ b/src/main/kotlin/auth/dto/AdminAuthToken.kt
@@ -6,7 +6,7 @@ data class AdminAuthToken(
     val authority: String,
 ) {
     companion object {
-        fun from(accessToken: String, name: String, authority: String): AdminAuthToken {
+        fun of(accessToken: String, name: String, authority: String): AdminAuthToken {
             return AdminAuthToken(accessToken, name, authority)
         }
     }

--- a/src/main/kotlin/domain/admin/repository/OrganizationRepository.kt
+++ b/src/main/kotlin/domain/admin/repository/OrganizationRepository.kt
@@ -1,8 +1,18 @@
 package uket.domain.admin.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import uket.domain.admin.entity.Organization
 
 interface OrganizationRepository : JpaRepository<Organization, Long> {
     fun findByName(name: String): Organization?
+
+    @Query("""
+    SELECT COUNT(o) > 0 FROM Organization o
+    WHERE o.name = :name
+    AND o.id NOT IN (
+        SELECT a.organization.id FROM Admin a
+    )
+    """)
+    fun existsByNameAndNotRegistered(name: String): Boolean
 }

--- a/src/main/kotlin/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/domain/admin/service/AdminService.kt
@@ -14,10 +14,10 @@ import uket.domain.admin.entity.Organization
 import uket.domain.admin.repository.AdminRepository
 
 @Service
-@Transactional(readOnly = true)
 class AdminService(
     private val adminRepository: AdminRepository,
 ) {
+    @Transactional(readOnly = true)
     fun getById(adminId: Long): Admin {
         val admin = adminRepository.findByIdOrNull(adminId)
             ?: throw IllegalStateException("해당 어드민을 찾을 수 없습니다")
@@ -27,6 +27,7 @@ class AdminService(
     fun getByEmail(email: String): Admin = adminRepository.findByEmail(email)
         ?: throw IllegalStateException("해당 어드민을 찾을 수 없습니다")
 
+    @Transactional(readOnly = true)
     fun findAdminsWithOrganizationIdByPage(pageRequest: PageRequest): Page<AdminWithOrganizationIdDto> {
         val ids = adminRepository.findAdminIds(pageRequest)
         val admins = adminRepository.findAllByIdsOrderByCreatedAtDesc(ids)
@@ -53,7 +54,6 @@ class AdminService(
         adminRepository.save(admin)
     }
 
-    @Transactional
     fun registerAdminWithoutPassword(name: String, email: String, authority: String, organization: Organization): Admin {
         check(adminRepository.existsByEmail(email).not()) { "이미 가입된 어드민입니다." }
 
@@ -73,7 +73,6 @@ class AdminService(
         return adminRepository.save(admin)
     }
 
-    @Transactional
     fun updatePassword(email: String, password: String): Admin {
         val admin: Admin = getByEmail(email)
         admin.updatePassword(password)

--- a/src/main/kotlin/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/domain/admin/service/AdminService.kt
@@ -54,18 +54,18 @@ class AdminService(
     }
 
     @Transactional
-    fun registerAdminWithoutPassword(command: RegisterAdminWithoutPasswordCommand, organization: Organization): Admin {
-        check(adminRepository.existsByEmail(command.email).not()) { "이미 가입된 어드민입니다." }
+    fun registerAdminWithoutPassword(name: String, email: String, authority: String, organization: Organization): Admin {
+        check(adminRepository.existsByEmail(email).not()) { "이미 가입된 어드민입니다." }
 
-        val isSuperAdmin = when (command.authority) {
+        val isSuperAdmin = when (authority) {
             "관리자" -> true
             else -> false
         }
 
         val admin = Admin(
             organization = organization,
-            name = command.name,
-            email = command.email,
+            name = name,
+            email = email,
             isSuperAdmin = isSuperAdmin,
             password = null,
         )

--- a/src/main/kotlin/domain/admin/service/OrganizationService.kt
+++ b/src/main/kotlin/domain/admin/service/OrganizationService.kt
@@ -18,7 +18,6 @@ class OrganizationService(
         return organization
     }
 
-    @Transactional(readOnly = true)
     fun getByName(name: String): Organization {
         val organization = organizationRepository.findByName(name)
             ?: throw IllegalStateException("단체를 찾을 수 없습니다.")
@@ -30,5 +29,9 @@ class OrganizationService(
     fun findAllIdAndNames(): List<OrganizationDropdownItem> {
         val organizations = organizationRepository.findAll()
         return organizations.stream().map { o -> OrganizationDropdownItem.from(o) }.toList()
+    }
+
+    fun checkDuplicateOrganizationRegister(name: String) {
+        check(organizationRepository.existsByNameAndNotRegistered(name)) { "이미 관리자로 등록된 단체입니다." }
     }
 }

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -47,7 +47,7 @@ class AdminAuthEmailFacade(
         redisUtil.setDataExpire(EMAIL_TOKEN_PREFIX + token, admin.email, EMAIL_TOKEN_EXPIRATION_MILLIS.toLong())
 
         val subject = "[Uket admin] 회원가입 링크 안내"
-        val content = loadAdminInviteHtml(token)
+        val content = loadAdminInviteHtml(admin.email, token)
 
         mailService.sendEmailWithHtmlContent(admin.email, subject, content)
         return SendEmailResponse.from(admin)
@@ -90,7 +90,7 @@ class AdminAuthEmailFacade(
         }
     }
 
-    private fun loadAdminInviteHtml(token: String): String {
+    private fun loadAdminInviteHtml(email: String, token: String): String {
         val template = ClassPathResource("static/invite.html")
             .inputStream
             .bufferedReader()
@@ -98,7 +98,7 @@ class AdminAuthEmailFacade(
 
         return template
             .replace("{{IMAGE_URL}}", emailProperties.urls.imageUrl)
-            .replace("{{SIGNUP_LINK}}", "${emailProperties.urls.baseUrl}?token=$token")
+            .replace("{{SIGNUP_LINK}}", "${emailProperties.urls.baseUrl}?email=$email?token=$token")
     }
 
     private fun validateRegistered(admin: Admin) {

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -4,6 +4,7 @@ import org.springframework.core.io.ClassPathResource
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uket.api.admin.request.RegisterAdminPasswordCommand
+import uket.api.admin.request.SendEmailRequest
 import uket.api.admin.response.RegisterAdminResponse
 import uket.api.admin.response.SendEmailResponse
 import uket.auth.dto.AdminAuthToken
@@ -33,10 +34,10 @@ class AdminAuthEmailFacade(
         private const val EMAIL_TOKEN_EXPIRATION_MILLIS = 1000 * 60 * 60 * 24 // 24시간
     }
 
-    fun sendAuthEmail(command: RegisterAdminWithoutPasswordCommand): SendEmailResponse {
-        validateEmail(command.email)
-        val organization: Organization = organizationService.getByName(command.organization)
-        val admin = adminService.registerAdminWithoutPassword(command, organization)
+    fun sendAuthEmail(request: SendEmailRequest): SendEmailResponse {
+        validateEmail(request.email)
+        val organization: Organization = organizationService.getByName(request.organization)
+        val admin = adminService.registerAdminWithoutPassword(request.name,request.email,request.authority, organization)
 
         val token = jwtAuthTokenUtil.createEmailToken(
             admin.id,

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -71,7 +71,7 @@ class AdminAuthEmailFacade(
             java.lang.String.valueOf(UserRole.ADMIN),
             true,
         )
-        return AdminAuthToken.from(accessToken, admin.name, authority)
+        return AdminAuthToken.of(accessToken, admin.name, authority)
     }
 
     private fun validateEmail(email: String) {

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -9,7 +9,6 @@ import uket.api.admin.response.RegisterAdminResponse
 import uket.api.admin.response.SendEmailResponse
 import uket.auth.dto.AdminAuthToken
 import uket.auth.jwt.JwtAuthTokenUtil
-import uket.domain.admin.dto.RegisterAdminWithoutPasswordCommand
 import uket.domain.admin.entity.Admin
 import uket.domain.admin.entity.Organization
 import uket.domain.admin.service.AdminService
@@ -20,7 +19,6 @@ import uket.modules.email.service.MailSendService
 import uket.modules.redis.util.RedisUtil
 
 @Service
-@Transactional
 class AdminAuthEmailFacade(
     private val mailService: MailSendService,
     private val adminService: AdminService,
@@ -34,6 +32,7 @@ class AdminAuthEmailFacade(
         private const val EMAIL_TOKEN_EXPIRATION_MILLIS = 1000 * 60 * 60 * 24 // 24시간
     }
 
+    @Transactional
     fun sendAuthEmail(request: SendEmailRequest): SendEmailResponse {
         validateEmail(request.email)
         val organization: Organization = organizationService.getByName(request.organization)
@@ -54,6 +53,7 @@ class AdminAuthEmailFacade(
         return SendEmailResponse.from(admin)
     }
 
+    @Transactional
     fun registerAdminWithPassword(token: String, command: RegisterAdminPasswordCommand): RegisterAdminResponse {
         validateEmailInRedis(token, command.email)
         val admin: Admin = adminService.updatePassword(command.email, command.password)
@@ -61,6 +61,7 @@ class AdminAuthEmailFacade(
         return RegisterAdminResponse.of(admin, admin.organization, authority)
     }
 
+    @Transactional(readOnly = true)
     fun login(email: String, password: String): AdminAuthToken {
         val admin = adminService.getByEmail(email)
         val authority: String = if (admin.isSuperAdmin) "관리자" else "멤버"

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -35,6 +35,7 @@ class AdminAuthEmailFacade(
     @Transactional
     fun sendAuthEmail(request: SendEmailRequest): SendEmailResponse {
         validateEmail(request.email)
+        validateOrganization(request.organization)
         val organization: Organization = organizationService.getByName(request.organization)
         val admin = adminService.registerAdminWithoutPassword(request.name,request.email,request.authority, organization)
 
@@ -80,9 +81,12 @@ class AdminAuthEmailFacade(
         adminService.checkDuplicateEmail(email)
     }
 
+    private fun validateOrganization(organizationName: String) {
+        organizationService.checkDuplicateOrganizationRegister(organizationName)
+    }
+
     private fun validateEmailInRedis(token: String, requestEmail: String) {
         val redisKey = EMAIL_TOKEN_PREFIX + token
-        System.out.println(redisKey)
         val savedEmail = redisUtil.getData(redisKey).orElseThrow {
             throw IllegalStateException("이메일 인증 토큰이 만료되었거나 유효하지 않습니다.")
         }

--- a/src/main/kotlin/modules/email/service/MailSendService.kt
+++ b/src/main/kotlin/modules/email/service/MailSendService.kt
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = true)
 class MailSendService(
     private val javaMailSender: JavaMailSender,
 ) {

--- a/src/main/resources/static/invite.html
+++ b/src/main/resources/static/invite.html
@@ -5,9 +5,22 @@
      style='width: 50%; height: auto; margin-bottom: 20px;'>
 <p>안녕하세요, Uket팀입니다.</p>
 <p>사용자 추가가 완료되어 하단의 회원가입 링크를 전달드립니다.</p>
-<br><p>회원가입을 완료한 후, 어드민 서비스를 이용해주세요.</p>
-<br><p style='font-weight: bold;'>Uket admin 회원가입 링크 :
-  <a href='{{SIGNUP_LINK}}'>{{SIGNUP_LINK}}</a></p>
-<br><p>감사합니다.</p>
+<br>
+<p>아래 링크를 통해 초대를 수락하고 비밀번호를 설정해주세요.<br>
+  설정이 완료되면 현재 이메일로 Uket 서비스를 이용하실 수 있습니다.</p>
+
+<br>
+<a href='{{SIGNUP_LINK}}' style="
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: #7250FD;
+    color: white;
+    text-decoration: none;
+    border-radius: 6px;
+    font-weight: bold;
+">초대수락</a>
+
+<br><br>
+<p>감사합니다.</p>
 </body>
 </html>

--- a/src/test/kotlin/uket/domain/admin/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uket/domain/admin/service/AdminServiceTest.kt
@@ -155,7 +155,12 @@ class AdminServiceTest :
                 every { adminRepository.existsByEmail(registerAdminWithoutPasswordCommand.email) } returns false
                 every { adminRepository.save(any()) } returns admin1
                 it("Admin을 생성한다") {
-                    adminService.registerAdminWithoutPassword(registerAdminWithoutPasswordCommand, organization)
+                    adminService.registerAdminWithoutPassword(
+                        registerAdminWithoutPasswordCommand.name,
+                        registerAdminWithoutPasswordCommand.email,
+                        registerAdminWithoutPasswordCommand.authority,
+                        organization
+                    )
                     verify(exactly = 1) { adminRepository.save(any()) }
                 }
             }
@@ -165,8 +170,10 @@ class AdminServiceTest :
                     val exception =
                         shouldThrow<IllegalStateException> {
                             adminService.registerAdminWithoutPassword(
-                                registerAdminWithoutPasswordCommand,
-                                organization,
+                                registerAdminWithoutPasswordCommand.name,
+                                registerAdminWithoutPasswordCommand.email,
+                                registerAdminWithoutPasswordCommand.authority,
+                                organization
                             )
                         }
                     exception.message shouldBe "이미 가입된 어드민입니다."


### PR DESCRIPTION
# 📌 개요
- 어드민 메일 발송 API 수정 작업을 진행했습니다.

# 💻 작업사항
- [x] 메일 내부의 연결 링크 버튼으로 변경
- [x] 링크 작성 시 token값과 함께 사용자 email 함께 전달
- [x] 메일 발송 전 이미 등록된 organization에 대한 검증 로직 추가

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
