### PR TITLE
[UKET-82] 예외 응답 메시지 구조 통일 및 핸들러 분리

### DIFF
--- a/src/main/kotlin/api/admin/handler/WebExceptionHandler.kt
+++ b/src/main/kotlin/api/admin/handler/WebExceptionHandler.kt
@@ -1,5 +1,6 @@
 package uket.api.admin.handler
 
+import io.swagger.v3.oas.annotations.Hidden
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.validation.ConstraintViolationException
 import org.springframework.http.ResponseEntity
@@ -17,15 +18,15 @@ import java.nio.CharBuffer
 import java.security.InvalidParameterException
 import java.time.format.DateTimeParseException
 
+@Hidden
 @RestControllerAdvice
-class WebExceptionHandler(
-) {
+class WebExceptionHandler() {
     private val log by LoggerDelegate()
 
     @ExceptionHandler(Exception::class)
     fun unKnownException(
         request: HttpServletRequest,
-        exception: Exception
+        exception: Exception,
     ): ResponseEntity<ErrorResponse> {
         return handleUnhandledException(request, exception)
     }
@@ -33,7 +34,7 @@ class WebExceptionHandler(
     @ExceptionHandler(DateTimeParseException::class)
     fun handleDateTimeParseException(
         request: HttpServletRequest,
-        exception: DateTimeParseException
+        exception: DateTimeParseException,
     ): ResponseEntity<ErrorResponse> {
         log.warn("[DateTimeParseException] {}", exception.message, exception)
         return ResponseEntity
@@ -44,7 +45,7 @@ class WebExceptionHandler(
     @ExceptionHandler(IllegalStateException::class)
     fun handleIllegalStateException(
         request: HttpServletRequest,
-        exception: IllegalStateException
+        exception: IllegalStateException,
     ): ResponseEntity<ErrorResponse> {
         log.warn("[IllegalStateException] {}", exception.message, exception)
         return ResponseEntity
@@ -52,11 +53,10 @@ class WebExceptionHandler(
             .body(ErrorResponse.from(exception.message ?: "잘못된 요청입니다."))
     }
 
-
     @ExceptionHandler(Throwable::class)
     fun handleUnhandledException(
         request: HttpServletRequest,
-        exception: Throwable
+        exception: Throwable,
     ): ResponseEntity<ErrorResponse> {
         val dump = dumpRequest(request).append("\n ")
             .append(getStackTraceAsString(exception))
@@ -77,7 +77,7 @@ class WebExceptionHandler(
     )
     fun handleValidationException(
         request: HttpServletRequest,
-        exception: Exception
+        exception: Exception,
     ): ResponseEntity<ErrorResponse> {
         log.warn("[ValidationException]", exception)
         return ResponseEntity

--- a/src/main/kotlin/api/admin/handler/WebExceptionHandler.kt
+++ b/src/main/kotlin/api/admin/handler/WebExceptionHandler.kt
@@ -1,0 +1,150 @@
+package uket.api.admin.handler
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.ServletRequestBindingException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import uket.common.LoggerDelegate
+import uket.common.response.ErrorResponse
+import java.io.IOException
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.nio.CharBuffer
+import java.security.InvalidParameterException
+import java.time.format.DateTimeParseException
+
+@RestControllerAdvice
+class WebExceptionHandler(
+) {
+    private val log by LoggerDelegate()
+
+    @ExceptionHandler(Exception::class)
+    fun unKnownException(
+        request: HttpServletRequest,
+        exception: Exception
+    ): ResponseEntity<ErrorResponse> {
+        return handleUnhandledException(request, exception)
+    }
+
+    @ExceptionHandler(DateTimeParseException::class)
+    fun handleDateTimeParseException(
+        request: HttpServletRequest,
+        exception: DateTimeParseException
+    ): ResponseEntity<ErrorResponse> {
+        log.warn("[DateTimeParseException] {}", exception.message, exception)
+        return ResponseEntity
+            .badRequest()
+            .body(ErrorResponse.from("날짜 형식이 올바르지 않습니다."))
+    }
+
+    @ExceptionHandler(IllegalStateException::class)
+    fun handleIllegalStateException(
+        request: HttpServletRequest,
+        exception: IllegalStateException
+    ): ResponseEntity<ErrorResponse> {
+        log.warn("[IllegalStateException] {}", exception.message, exception)
+        return ResponseEntity
+            .badRequest()
+            .body(ErrorResponse.from(exception.message ?: "잘못된 요청입니다."))
+    }
+
+
+    @ExceptionHandler(Throwable::class)
+    fun handleUnhandledException(
+        request: HttpServletRequest,
+        exception: Throwable
+    ): ResponseEntity<ErrorResponse> {
+        val dump = dumpRequest(request).append("\n ")
+            .append(getStackTraceAsString(exception))
+
+        log.error("[UnhandledException] {}\n", dump)
+
+        return ResponseEntity
+            .internalServerError()
+            .body(ErrorResponse.from("일시적으로 접속이 원활하지 않습니다. 서버 팀에 문의 부탁드립니다."))
+    }
+
+    @ExceptionHandler(
+        HttpMessageNotReadableException::class,
+        InvalidParameterException::class,
+        ServletRequestBindingException::class,
+        MethodArgumentNotValidException::class,
+        ConstraintViolationException::class,
+    )
+    fun handleValidationException(
+        request: HttpServletRequest,
+        exception: Exception
+    ): ResponseEntity<ErrorResponse> {
+        log.warn("[ValidationException]", exception)
+        return ResponseEntity
+            .badRequest()
+            .body(ErrorResponse.from("요청 값이 올바르지 않습니다."))
+    }
+
+    private fun getStackTraceAsString(throwable: Throwable): String {
+        val stringWriter = StringWriter()
+        throwable.printStackTrace(PrintWriter(stringWriter))
+        return stringWriter.toString()
+    }
+
+    private fun dumpRequest(request: HttpServletRequest): StringBuilder {
+        val dump = StringBuilder("HttpRequest Dump:")
+            .append("\n  Remote Addr   : ").append(request.remoteAddr)
+            .append("\n  Protocol      : ").append(request.protocol)
+            .append("\n  Request Method: ").append(request.method)
+            .append("\n  Request URI   : ").append(request.requestURI)
+            .append("\n  Query String  : ").append(request.queryString)
+            .append("\n  Parameters    : ")
+
+        val parameterNames = request.parameterNames
+        while (parameterNames.hasMoreElements()) {
+            val name = parameterNames.nextElement()
+            dump.append("\n    ").append(name).append('=')
+            val values = request.getParameterValues(name)
+            values?.forEach { dump.append(it) }
+        }
+
+        dump.append("\n  Headers       : ")
+        val headerNames = request.headerNames
+        while (headerNames.hasMoreElements()) {
+            val name = headerNames.nextElement()
+            dump.append("\n    ").append(name).append(":")
+            val headerValues = request.getHeaders(name)
+            while (headerValues.hasMoreElements()) {
+                dump.append(headerValues.nextElement())
+            }
+        }
+
+        dump.append("\n  Body       : ")
+        if (request.contentType?.contains("application/x-www-form-urlencoded") == true) {
+            dump.append("\n    Body is not readable for 'application/x-www-form-urlencoded' type or has been read")
+        } else {
+            try {
+                dump.append("\n    ").append(readableToString(request.reader))
+            } catch (ex: IOException) {
+                dump.append("\n    NOT_READABLE")
+            } catch (ex: IllegalStateException) {
+                dump.append("\n    BODY_ALREADY_READ")
+            }
+        }
+
+        return dump
+    }
+
+    private fun readableToString(readable: Readable): String {
+        val stringBuilder = StringBuilder()
+        val buffer = CharBuffer.allocate(1024)
+
+        while (readable.read(buffer) != -1) {
+            buffer.flip()
+            stringBuilder.append(buffer)
+            buffer.clear()
+        }
+
+        return stringBuilder.toString()
+    }
+}

--- a/src/main/kotlin/auth/filter/JwtAccessDeniedHandler.kt
+++ b/src/main/kotlin/auth/filter/JwtAccessDeniedHandler.kt
@@ -33,6 +33,6 @@ class JwtAccessDeniedHandler(
         response.characterEncoding = StandardCharsets.UTF_8.name()
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.status = HttpServletResponse.SC_FORBIDDEN
-        response.writer.write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.AUTHORIZATION_FAILED)))
+        response.writer.write(objectMapper.writeValueAsString(ErrorResponse.from(ErrorCode.AUTHORIZATION_FAILED)))
     }
 }

--- a/src/main/kotlin/auth/filter/JwtAuthenticationEntryPoint.kt
+++ b/src/main/kotlin/auth/filter/JwtAuthenticationEntryPoint.kt
@@ -30,6 +30,6 @@ class JwtAuthenticationEntryPoint(
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         response.writer
-            .write(objectMapper.writeValueAsString(ErrorResponse.of(ErrorCode.TOKEN_AUTHENTICATION_FAILED)))
+            .write(objectMapper.writeValueAsString(ErrorResponse.from(ErrorCode.TOKEN_AUTHENTICATION_FAILED)))
     }
 }

--- a/src/main/kotlin/auth/filter/JwtFilter.kt
+++ b/src/main/kotlin/auth/filter/JwtFilter.kt
@@ -67,7 +67,7 @@ class JwtFilter(
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         response.writer
-            .write(objectMapper.writeValueAsString(ErrorResponse.of(errorCode)))
+            .write(objectMapper.writeValueAsString(ErrorResponse.from(errorCode)))
     }
 
     private fun generateUserDto(accessToken: String): AuthenticationUserInfo {

--- a/src/main/kotlin/auth/interceptor/LoginInterceptor.kt
+++ b/src/main/kotlin/auth/interceptor/LoginInterceptor.kt
@@ -42,7 +42,7 @@ class LoginInterceptor(
         response.contentType = MediaType.APPLICATION_JSON_VALUE
         response.status = HttpServletResponse.SC_UNAUTHORIZED
         response.writer
-            .write(objectMapper.writeValueAsString(ErrorResponse.of(errorCode)))
+            .write(objectMapper.writeValueAsString(ErrorResponse.from(errorCode)))
     }
 
     private fun isSwaggerRequest(request: HttpServletRequest): Boolean {

--- a/src/main/kotlin/common/response/ErrorResponse.kt
+++ b/src/main/kotlin/common/response/ErrorResponse.kt
@@ -2,16 +2,17 @@ package uket.common.response
 
 import uket.common.ErrorCode
 
+
 data class ErrorResponse(
-    val code: String,
     val message: String,
 ) {
     companion object {
-        fun of(code: String, message: String): ErrorResponse = ErrorResponse(code, message)
+        fun from(message: String): ErrorResponse {
+            return ErrorResponse(message = message)
+        }
 
-        fun of(errorCode: ErrorCode, exception: Throwable? = null): ErrorResponse = ErrorResponse(
-            errorCode.code,
-            exception?.message ?: errorCode.message,
-        )
+        fun from(errorCode: ErrorCode): ErrorResponse {
+            return ErrorResponse(message = errorCode.message)
+        }
     }
 }

--- a/src/main/kotlin/common/response/ErrorResponse.kt
+++ b/src/main/kotlin/common/response/ErrorResponse.kt
@@ -2,7 +2,6 @@ package uket.common.response
 
 import uket.common.ErrorCode
 
-
 data class ErrorResponse(
     val message: String,
 ) {


### PR DESCRIPTION
# 📌 개요
- Exception 관련해 Handler 구현 및 ErrorResponse에서 code명을 삭제했습니다.

# 💻 작업사항
- [x] WebExceptionHandler 구현
- [x] ErrorResponse 메시지만 반환하도록 수정

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 저희가 반환하기로했던 IllegalStateException관련해서는 400으로 반환하고 unhandled관련해서 500으로 반환하는걸로 통일하려고하는데 더 나은 의견이 있다면 제시 부탁드립니다!
