### PR TITLE
[UKET-83] 어드민 로그인 응답 이메일 추가

### DIFF
--- a/src/main/kotlin/auth/dto/AdminAuthToken.kt
+++ b/src/main/kotlin/auth/dto/AdminAuthToken.kt
@@ -7,8 +7,8 @@ data class AdminAuthToken(
     val isSuperAdmin: Boolean,
 ) {
     companion object {
-        fun of(accessToken: String, name: String,email: String, isSuperAdmin: Boolean): AdminAuthToken {
-            return AdminAuthToken(accessToken, name,email, isSuperAdmin)
+        fun of(accessToken: String, name: String, email: String, isSuperAdmin: Boolean): AdminAuthToken {
+            return AdminAuthToken(accessToken, name, email, isSuperAdmin)
         }
     }
 }

--- a/src/main/kotlin/auth/dto/AdminAuthToken.kt
+++ b/src/main/kotlin/auth/dto/AdminAuthToken.kt
@@ -3,11 +3,12 @@ package uket.auth.dto
 data class AdminAuthToken(
     val accessToken: String,
     val name: String,
-    val authority: String,
+    val email: String,
+    val isSuperAdmin: Boolean,
 ) {
     companion object {
-        fun from(accessToken: String, name: String, authority: String): AdminAuthToken {
-            return AdminAuthToken(accessToken, name, authority)
+        fun of(accessToken: String, name: String,email: String, isSuperAdmin: Boolean): AdminAuthToken {
+            return AdminAuthToken(accessToken, name,email, isSuperAdmin)
         }
     }
 }

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -62,6 +62,7 @@ class AdminAuthEmailFacade(
 
     fun login(email: String, password: String): AdminAuthToken {
         val admin = adminService.getByEmail(email)
+        checkNotNull(admin.password) { "초대 메일을 통해 회원가입 후 이용 바랍니다." }
 
         validateRegistered(admin)
         val accessToken = jwtAuthTokenUtil.createAccessToken(

--- a/src/main/kotlin/facade/AdminAuthEmailFacade.kt
+++ b/src/main/kotlin/facade/AdminAuthEmailFacade.kt
@@ -62,16 +62,15 @@ class AdminAuthEmailFacade(
 
     fun login(email: String, password: String): AdminAuthToken {
         val admin = adminService.getByEmail(email)
-        val authority: String = if (admin.isSuperAdmin) "관리자" else "멤버"
 
         validateRegistered(admin)
         val accessToken = jwtAuthTokenUtil.createAccessToken(
             admin.id,
             admin.name,
-            java.lang.String.valueOf(UserRole.ADMIN),
+            UserRole.ADMIN.toString(),
             true,
         )
-        return AdminAuthToken.from(accessToken, admin.name, authority)
+        return AdminAuthToken.of(accessToken, admin.name, admin.email, admin.isSuperAdmin)
     }
 
     private fun validateEmail(email: String) {


### PR DESCRIPTION
# 📌 개요
- 어드민 로그인 진행시에 응답으로 이메일 내용을 추가했습니다.

# 💻 작업사항
- [x] 어드민 로그인 진행 시 응답에 이메일 추가
- [x] password 등록 전일경우 예외처리 하도록 validation code 구현

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
