### PR TITLE
[UKET-85] 에러 핸들링 구조 수정

### DIFF
--- a/src/main/kotlin/common/ControllerAdvice.kt
+++ b/src/main/kotlin/common/ControllerAdvice.kt
@@ -1,0 +1,145 @@
+package uket.common
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.ConstraintViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.ServletRequestBindingException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import uket.common.response.PublicErrorResponse
+import java.io.IOException
+import java.nio.CharBuffer
+import java.security.InvalidParameterException
+import java.time.format.DateTimeParseException
+
+@RestControllerAdvice
+class ControllerAdvice {
+    private val log by LoggerDelegate()
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Throwable::class)
+    fun unknownException(
+        request: HttpServletRequest,
+        exception: Exception,
+    ): PublicErrorResponse {
+        log.error("[UnhandledException] ${dumpRequest(request)}", exception)
+
+        return PublicErrorResponse.error(exception = exception)
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(DateTimeParseException::class)
+    fun handleDateTimeParseException(
+        request: HttpServletRequest,
+        exception: DateTimeParseException,
+    ): PublicErrorResponse {
+        return PublicErrorResponse.warn(exception = exception)
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalStateException::class)
+    fun handleIllegalStateException(
+        request: HttpServletRequest,
+        exception: IllegalStateException,
+    ): PublicErrorResponse {
+        return PublicErrorResponse.error(exception = exception)
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(
+        request: HttpServletRequest,
+        exception: IllegalArgumentException,
+    ): PublicErrorResponse {
+        return PublicErrorResponse.error(exception = exception)
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(
+        HttpMessageNotReadableException::class,
+        InvalidParameterException::class,
+        ServletRequestBindingException::class,
+        MethodArgumentNotValidException::class,
+        ConstraintViolationException::class,
+    )
+    fun handleValidationException(
+        request: HttpServletRequest,
+        exception: Exception,
+    ): PublicErrorResponse {
+        return PublicErrorResponse.warn(exception = exception)
+    }
+
+    @ExceptionHandler(PublicException::class)
+    fun handlePublicException(
+        request: HttpServletRequest,
+        exception: PublicException,
+    ): ResponseEntity<PublicErrorResponse> {
+        return ResponseEntity.status(exception.httpStatus).body(
+            PublicErrorResponse.withErrorLevel(
+                title = exception.title,
+                publicMessage = exception.publicMessage,
+                systemMessage = exception.systemMessage,
+                errorLevel = exception.errorLevel,
+                exception = exception
+            )
+        )
+    }
+
+    private fun dumpRequest(request: HttpServletRequest): StringBuilder {
+        val dump = StringBuilder("HttpRequest Dump:").append("\n  Remote Addr   : ").append(request.remoteAddr)
+            .append("\n  Protocol      : ").append(request.protocol).append("\n  Request Method: ")
+            .append(request.method).append("\n  Request URI   : ").append(request.requestURI)
+            .append("\n  Query String  : ").append(request.queryString).append("\n  Parameters    : ")
+
+        val parameterNames = request.parameterNames
+        while (parameterNames.hasMoreElements()) {
+            val name = parameterNames.nextElement()
+            dump.append("\n    ").append(name).append('=')
+            val values = request.getParameterValues(name)
+            values?.forEach { dump.append(it) }
+        }
+
+        dump.append("\n  Headers       : ")
+        val headerNames = request.headerNames
+        while (headerNames.hasMoreElements()) {
+            val name = headerNames.nextElement()
+            dump.append("\n    ").append(name).append(":")
+            val headerValues = request.getHeaders(name)
+            while (headerValues.hasMoreElements()) {
+                dump.append(headerValues.nextElement())
+            }
+        }
+
+        dump.append("\n  Body       : ")
+        if (request.contentType?.contains("application/x-www-form-urlencoded") == true) {
+            dump.append("\n    Body is not readable for 'application/x-www-form-urlencoded' type or has been read")
+        } else {
+            try {
+                dump.append("\n    ").append(readableToString(request.reader))
+            } catch (ex: IOException) {
+                dump.append("\n    NOT_READABLE")
+            } catch (ex: IllegalStateException) {
+                dump.append("\n    BODY_ALREADY_READ")
+            }
+        }
+
+        return dump
+    }
+
+    private fun readableToString(readable: Readable): String {
+        val stringBuilder = StringBuilder()
+        val buffer = CharBuffer.allocate(1024)
+
+        while (readable.read(buffer) != -1) {
+            buffer.flip()
+            stringBuilder.append(buffer)
+            buffer.clear()
+        }
+
+        return stringBuilder.toString()
+    }
+}

--- a/src/main/kotlin/common/PublicException.kt
+++ b/src/main/kotlin/common/PublicException.kt
@@ -1,0 +1,26 @@
+package uket.common
+
+import org.springframework.http.HttpStatus
+
+open class PublicException(
+    val publicMessage: String? = null,
+    val systemMessage: String? = publicMessage,
+    val title: String? = null,
+    val errorLevel: ErrorLevel = ErrorLevel.ERROR,
+    val httpStatus: HttpStatus = HttpStatus.BAD_REQUEST,
+) : RuntimeException()
+
+class PublicNotFoundException(
+    publicMessage: String? = null,
+    systemMessage: String? = publicMessage,
+    title: String? = null,
+    errorLevel: ErrorLevel = ErrorLevel.ERROR,
+) : PublicException(publicMessage, systemMessage, title, errorLevel, HttpStatus.NOT_FOUND)
+
+enum class ErrorLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+}

--- a/src/main/kotlin/common/response/PublicErrorResponse.kt
+++ b/src/main/kotlin/common/response/PublicErrorResponse.kt
@@ -1,0 +1,108 @@
+package uket.common.response
+
+import uket.common.ErrorLevel
+import uket.common.LoggerDelegate
+
+const val DEFAULT_PUBLIC_ERROR_TITLE = "잠시 후 다시 시도해 주세요!"
+const val DEFAULT_PUBLIC_ERROR_MESSAGE = "이용에 불편을 드려 죄송합니다.\n네트워크 또는 데이터 오류로 페이지를 불러오지 못하였습니다.\n잠시 후 다시 시도해 주세요."
+
+data class PublicErrorResponse(
+    val title: String? = DEFAULT_PUBLIC_ERROR_TITLE,
+    val message: String? = DEFAULT_PUBLIC_ERROR_MESSAGE,
+    val errorLevel: ErrorLevel = ErrorLevel.ERROR,
+) {
+    companion object {
+        private val log by LoggerDelegate()
+
+        fun withErrorLevel(
+            title: String? = null,
+            publicMessage: String? = null,
+            systemMessage: String? = null,
+            errorLevel: ErrorLevel,
+            exception: Throwable,
+        ): PublicErrorResponse {
+            return when (errorLevel) {
+                ErrorLevel.TRACE -> trace(title, publicMessage, systemMessage, exception)
+                ErrorLevel.DEBUG -> debug(title, publicMessage, systemMessage, exception)
+                ErrorLevel.INFO -> info(title, publicMessage, systemMessage, exception)
+                ErrorLevel.WARN -> warn(title, publicMessage, systemMessage, exception)
+                ErrorLevel.ERROR -> error(title, publicMessage, systemMessage, exception)
+            }
+        }
+
+        fun trace(
+            title: String? = null,
+            publicMessage: String? = null,
+            systemMessage: String? = null,
+            exception: Throwable,
+        ): PublicErrorResponse {
+            log.trace(systemMessage ?: exception.message, exception)
+
+            return PublicErrorResponse(
+                title = title,
+                message = publicMessage,
+                errorLevel = ErrorLevel.TRACE
+            )
+        }
+
+        fun debug(
+            title: String? = null,
+            publicMessage: String? = null,
+            systemMessage: String? = null,
+            exception: Throwable,
+        ): PublicErrorResponse {
+            log.debug(systemMessage ?: exception.message, exception)
+
+            return PublicErrorResponse(
+                title = title,
+                message = publicMessage,
+                errorLevel = ErrorLevel.DEBUG
+            )
+        }
+
+        fun info(
+            title: String? = null,
+            publicMessage: String? = null,
+            systemMessage: String? = null,
+            exception: Throwable,
+        ): PublicErrorResponse {
+            log.info(systemMessage ?: exception.message, exception)
+
+            return PublicErrorResponse(
+                title = title,
+                message = publicMessage,
+                errorLevel = ErrorLevel.INFO
+            )
+        }
+
+        fun warn(
+            title: String? = null,
+            publicMessage: String? = null,
+            systemMessage: String? = null,
+            exception: Throwable,
+        ): PublicErrorResponse {
+            log.warn(systemMessage ?: exception.message, exception)
+
+            return PublicErrorResponse(
+                title = title,
+                message = publicMessage,
+                errorLevel = ErrorLevel.WARN
+            )
+        }
+
+        fun error(
+            title: String? = null,
+            publicMessage: String? = null,
+            systemMessage: String? = null,
+            exception: Throwable,
+        ): PublicErrorResponse {
+            log.error(systemMessage ?: exception.message, exception)
+
+            return PublicErrorResponse(
+                title = title,
+                message = publicMessage,
+                errorLevel = ErrorLevel.ERROR
+            )
+        }
+    }
+}


### PR DESCRIPTION
# 📌 개요
- 에러 핸들링 구조 수정했습니다.
- title: 사용자에게 노출할 에러 메세지 제목
- publicMessage: 사용자에게 노출할 에러 메세지
- systemMessage: 서버 로깅용 메세지
- 

# 💻 작업사항
- [x] 에러 핸들링 구조 수정

# ❌ 주의사항
- N/A

# 💡 코드 리뷰 요청사항
- N/A
