### PR TITLE
[UKET-88] 행사 목록 조회 API 마이그레이션

### DIFF
--- a/src/main/kotlin/api/user/EventController.kt
+++ b/src/main/kotlin/api/user/EventController.kt
@@ -3,6 +3,7 @@ package uket.api.user
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uket.api.user.response.ActiveEventsResponse
 import uket.domain.uketevent.service.UketEventService
@@ -13,8 +14,10 @@ class EventController(
 ) {
     @Operation(summary = "활성화된 축제 목록 조회", description = "유저가 조회 가능한 축제 목록을 가져옵니다")
     @GetMapping("/uket-events")
-    fun getEvents(): ResponseEntity<ActiveEventsResponse> {
-        uketEventService
-        return ResponseEntity.ok(ActiveEventsResponse(listOf()))
+    fun getEvents(
+        @RequestParam("type") type: EventListQueryType,
+    ): ResponseEntity<ActiveEventsResponse> {
+        val itemList = uketEventService.getActiveEventItemList(type = type)
+        return ResponseEntity.ok(ActiveEventsResponse(itemList))
     }
 }

--- a/src/main/kotlin/api/user/EventController.kt
+++ b/src/main/kotlin/api/user/EventController.kt
@@ -1,0 +1,20 @@
+package uket.api.user
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+import uket.api.user.response.ActiveEventsResponse
+import uket.domain.uketevent.service.UketEventService
+
+@RestController
+class EventController(
+    val uketEventService: UketEventService,
+) {
+    @Operation(summary = "활성화된 축제 목록 조회", description = "유저가 조회 가능한 축제 목록을 가져옵니다")
+    @GetMapping("/uket-events")
+    fun getEvents(): ResponseEntity<ActiveEventsResponse> {
+        uketEventService
+        return ResponseEntity.ok(ActiveEventsResponse(listOf()))
+    }
+}

--- a/src/main/kotlin/api/user/EventController.kt
+++ b/src/main/kotlin/api/user/EventController.kt
@@ -18,7 +18,6 @@ class EventController(
         @RequestParam("type") type: EventListQueryType,
     ): ResponseEntity<ActiveEventsResponse> {
         val itemList = uketEventService.getActiveEventItemList(type = type)
-        println(itemList.map { it.eventName })
         return ResponseEntity.ok(ActiveEventsResponse(itemList))
     }
 }

--- a/src/main/kotlin/api/user/EventController.kt
+++ b/src/main/kotlin/api/user/EventController.kt
@@ -18,6 +18,7 @@ class EventController(
         @RequestParam("type") type: EventListQueryType,
     ): ResponseEntity<ActiveEventsResponse> {
         val itemList = uketEventService.getActiveEventItemList(type = type)
+        println(itemList.map { it.eventName })
         return ResponseEntity.ok(ActiveEventsResponse(itemList))
     }
 }

--- a/src/main/kotlin/api/user/EventListQueryType.kt
+++ b/src/main/kotlin/api/user/EventListQueryType.kt
@@ -1,0 +1,7 @@
+package uket.api.user
+
+enum class EventListQueryType {
+    ALL,
+    FESTIVAL,
+    PERFORMANCE,
+}

--- a/src/main/kotlin/api/user/response/ActiveEventsResponse.kt
+++ b/src/main/kotlin/api/user/response/ActiveEventsResponse.kt
@@ -1,0 +1,7 @@
+package uket.api.user.response
+
+import uket.domain.uketevent.dto.EventListItem
+
+data class ActiveEventsResponse(
+    private val events: List<EventListItem>,
+)

--- a/src/main/kotlin/api/user/response/ActiveEventsResponse.kt
+++ b/src/main/kotlin/api/user/response/ActiveEventsResponse.kt
@@ -3,5 +3,5 @@ package uket.api.user.response
 import uket.domain.uketevent.dto.EventListItem
 
 data class ActiveEventsResponse(
-    private val events: List<EventListItem>,
+    val events: List<EventListItem>,
 )

--- a/src/main/kotlin/auth/config/AuthConfig.kt
+++ b/src/main/kotlin/auth/config/AuthConfig.kt
@@ -11,7 +11,8 @@ class AuthConfig(
     private val loginInterceptor: LoginInterceptor,
 ) : WebMvcConfigurer {
     override fun addInterceptors(registry: InterceptorRegistry) {
-        registry.addInterceptor(loginInterceptor)
+        registry
+            .addInterceptor(loginInterceptor)
             .excludePathPatterns("/api/v1/dev/**")
             .excludePathPatterns("/api/v1/email/**")
             .excludePathPatterns("/api/v1/auth/**")
@@ -19,10 +20,12 @@ class AuthConfig(
             .excludePathPatterns("/admin/**")
             .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
             .excludePathPatterns("/admin/users/login")
+            .excludePathPatterns("/uket-events/**")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {
-        registry.addResourceHandler("/favicon.ico")
+        registry
+            .addResourceHandler("/favicon.ico")
             .addResourceLocations("classpath:/static/favicon.ico")
             .setCachePeriod(3600) // 1시간 캐시
     }

--- a/src/main/kotlin/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/auth/config/SecurityConfig.kt
@@ -25,14 +25,10 @@ class SecurityConfig(
 ) {
     @Bean
     @Throws(Exception::class)
-    fun authenticationManager(configuration: AuthenticationConfiguration): AuthenticationManager {
-        return configuration.authenticationManager
-    }
+    fun authenticationManager(configuration: AuthenticationConfiguration): AuthenticationManager = configuration.authenticationManager
 
     @Bean
-    fun bCryptPasswordEncoder(): BCryptPasswordEncoder {
-        return BCryptPasswordEncoder()
-    }
+    fun bCryptPasswordEncoder(): BCryptPasswordEncoder = BCryptPasswordEncoder()
 
     @Bean
     @Throws(Exception::class)
@@ -42,7 +38,8 @@ class SecurityConfig(
                 cors.configurationSource {
                     val configuration = CorsConfiguration()
                     configuration.allowedMethods = listOf(
-                        *ALLOWED_METHOD_NAMES.split(",".toRegex())
+                        *ALLOWED_METHOD_NAMES
+                            .split(",".toRegex())
                             .dropLastWhile { it.isEmpty() }
                             .toTypedArray(),
                     )
@@ -55,47 +52,54 @@ class SecurityConfig(
                     )
                     configuration
                 }
-            }
-            .csrf {
+            }.csrf {
                 it.disable()
-            }
-            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
+            }.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
             .exceptionHandling { exceptionHandlerManagement ->
                 exceptionHandlerManagement
                     .authenticationEntryPoint(entryPoint)
                     .accessDeniedHandler(accessDeniedHandler)
-            }
-            .authorizeHttpRequests { registry ->
-                registry.requestMatchers("/favicon.ico").permitAll()
-                    .requestMatchers("/error").permitAll()
-            }
-            .authorizeHttpRequests { registry ->
+            }.authorizeHttpRequests { registry ->
+                registry
+                    .requestMatchers("/favicon.ico")
+                    .permitAll()
+                    .requestMatchers("/error")
+                    .permitAll()
+            }.authorizeHttpRequests { registry ->
                 registry // actuator, rest docs 경로, 실무에서는 상황에 따라 적절한 접근제어 필요
-                    .requestMatchers("/actuator/*").permitAll()
-                    .requestMatchers("/swagger-ui.html").permitAll()
-                    .requestMatchers("/swagger-ui/**").permitAll()
-                    .requestMatchers("/v3/api-docs/**").permitAll()
-                    .requestMatchers("/admin/**").permitAll()
-            }
-            .authorizeHttpRequests { registry ->
+                    .requestMatchers("/actuator/*")
+                    .permitAll()
+                    .requestMatchers("/swagger-ui.html")
+                    .permitAll()
+                    .requestMatchers("/swagger-ui/**")
+                    .permitAll()
+                    .requestMatchers("/v3/api-docs/**")
+                    .permitAll()
+                    .requestMatchers("/admin/**")
+                    .permitAll()
+            }.authorizeHttpRequests { registry ->
                 registry
-                    .requestMatchers("/api/v1/auth").permitAll()
-                    .requestMatchers("/api/v1/auth/login/**").permitAll()
-            }
-            .authorizeHttpRequests { registry ->
+                    .requestMatchers("/api/v1/auth")
+                    .permitAll()
+                    .requestMatchers("/api/v1/auth/login/**")
+                    .permitAll()
+            }.authorizeHttpRequests { registry ->
                 registry
-                    .requestMatchers("/api/v1/dev/token").permitAll()
-                    .requestMatchers("/api/v1/dev/token/registered").permitAll()
-            }
-            .authorizeHttpRequests { registry ->
+                    .requestMatchers("/api/v1/dev/token")
+                    .permitAll()
+                    .requestMatchers("/api/v1/dev/token/registered")
+                    .permitAll()
+            }.authorizeHttpRequests { registry ->
                 registry
-                    .requestMatchers("/admin/users/login").permitAll()
-            }
-            .authorizeHttpRequests { registry ->
+                    .requestMatchers("/admin/users/login")
+                    .permitAll()
+                    .requestMatchers("/uket-events/**")
+                    .permitAll()
+            }.authorizeHttpRequests { registry ->
                 registry
-                    .anyRequest().authenticated()
-            }
-            .sessionManagement { session ->
+                    .anyRequest()
+                    .authenticated()
+            }.sessionManagement { session ->
                 session
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             }

--- a/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
+++ b/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
@@ -24,7 +24,7 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
         AND t.status NOT IN :status
         AND t.entryGroupId IN (
             SELECT eg.id FROM EntryGroup eg
-            WHERE eg.uketEventRound.uketEvent.displayEndDate > CURRENT_TIMESTAMP
+            WHERE eg.uketEventRound.eventRoundDateTime > CURRENT_TIMESTAMP
         )
     """,
     )

--- a/src/main/kotlin/domain/uketevent/converter/ListToStringConverter.kt
+++ b/src/main/kotlin/domain/uketevent/converter/ListToStringConverter.kt
@@ -1,0 +1,11 @@
+package uket.domain.uketevent.converter
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter(autoApply = true)
+class ListToStringConverter : AttributeConverter<List<String>, String> {
+    override fun convertToDatabaseColumn(list: List<String>?): String = list?.joinToString().orEmpty()
+
+    override fun convertToEntityAttribute(data: String?): List<String> = data?.split(",") ?: emptyList()
+}

--- a/src/main/kotlin/domain/uketevent/dto/EventListItem.kt
+++ b/src/main/kotlin/domain/uketevent/dto/EventListItem.kt
@@ -1,14 +1,16 @@
 package uket.domain.uketevent.dto
 
+import uket.domain.uketevent.enums.TicketingStatus
 import java.time.LocalDateTime
 
 data class EventListItem(
-    private val eventName: String,
-    private val eventThumbnailImagePath: String,
-    private val eventStartDate: LocalDateTime,
-    private val eventEndDate: LocalDateTime,
-    private val ticketingStartDate: LocalDateTime,
-    private val ticketingEndDate: LocalDateTime,
+    val eventName: String,
+    val eventThumbnailImagePath: String,
+    val eventStartDate: LocalDateTime,
+    val eventEndDate: LocalDateTime,
+    val ticketingStartDate: LocalDateTime,
+    val ticketingEndDate: LocalDateTime,
+    val ticketingStatus: TicketingStatus,
 ) {
 //    fun from(uketEvent: UketEvent): EventListItem {
 //        return EventListItem(

--- a/src/main/kotlin/domain/uketevent/dto/EventListItem.kt
+++ b/src/main/kotlin/domain/uketevent/dto/EventListItem.kt
@@ -1,0 +1,23 @@
+package uket.domain.uketevent.dto
+
+import java.time.LocalDateTime
+
+data class EventListItem(
+    private val eventName: String,
+    private val eventThumbnailImagePath: String,
+    private val eventStartDate: LocalDateTime,
+    private val eventEndDate: LocalDateTime,
+    private val ticketingStartDate: LocalDateTime,
+    private val ticketingEndDate: LocalDateTime,
+) {
+//    fun from(uketEvent: UketEvent): EventListItem {
+//        return EventListItem(
+//            eventName = uketEvent.eventName,
+//            eventThumbnailImagePath = uketEvent.thumbnailImageId,
+//            eventStartDate = uketEvent.,
+//            eventEndDate =,
+//            ticketingStartDate = uketEvent.ticketingStartDateTime,
+//            ticketingEndDate = uketEvent.ticketingEndDateTime
+//        )
+//    }
+}

--- a/src/main/kotlin/domain/uketevent/entity/EntryGroup.kt
+++ b/src/main/kotlin/domain/uketevent/entity/EntryGroup.kt
@@ -1,6 +1,8 @@
 package uket.domain.uketevent.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -16,30 +18,38 @@ class EntryGroup(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uket_event_round_id", nullable = false)
     val uketEventRound: UketEventRound,
-    val name: String,
-    val entryStartTime: LocalDateTime,
-    val entryEndTime: LocalDateTime,
-    var reservationCount: Int,
-    val totalCount: Int,
-) : BaseTimeEntity() {
-    fun increaseReservedCount(): Boolean {
-        if (this.reservationCount + 1 > this.totalCount) {
-            return false
-        }
 
-        this.reservationCount += 1
-        return true
-    }
+    @Column(name = "entry_group_name")
+    val entryGroupName: String,
+
+    @Column(name = "entry_start_datetime")
+    val entryStartDateTime: LocalDateTime,
+
+    @Column(name = "entry_end_datetime")
+    val entryEndDateTime: LocalDateTime,
+
+    @Column(name = "ticket_count")
+    var ticketCount: Int,
+) : BaseTimeEntity() {
+//    fun increaseReservedCount(): Boolean {
+//        if (this.ticketCount + 1 > this.totalCount) {
+//            return false
+//        }
+//
+//        this.ticketCount += 1
+//        return true
+//    }
 
     fun decreaseReservedCount(): Boolean {
-        if (this.reservationCount < 1) {
+        if (this.ticketCount < 1) {
             return false
         }
 
-        this.reservationCount -= 1
+        this.ticketCount -= 1
         return true
     }
 }

--- a/src/main/kotlin/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/domain/uketevent/entity/UketEvent.kt
@@ -71,7 +71,7 @@ class UketEvent(
         orphanRemoval = true,
         cascade = [CascadeType.ALL],
     )
-    val uketEventRounds: List<UketEventRound> = _uketEventRounds.map {
+    var uketEventRounds: List<UketEventRound> = _uketEventRounds.map {
         UketEventRound(
             id = it.id,
             uketEvent = this,
@@ -101,5 +101,10 @@ class UketEvent(
             INSTAGRAM,
             KAKAO,
         }
+    }
+
+    fun addUketEventRound(uketEventRound: UketEventRound) {
+        this.uketEventRounds += uketEventRound
+        uketEventRound.uketEvent = this
     }
 }

--- a/src/main/kotlin/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/domain/uketevent/entity/UketEvent.kt
@@ -1,14 +1,22 @@
 package uket.domain.uketevent.entity
 
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Convert
+import jakarta.persistence.Embeddable
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import uket.common.enums.EventType
 import uket.domain.BaseTimeEntity
+import uket.domain.uketevent.converter.ListToStringConverter
 import java.time.LocalDateTime
 
 @Entity
@@ -17,12 +25,81 @@ class UketEvent(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
+
+    @Column(name = "organization_id")
     val organizationId: Long,
-    val name: String,
+
+    @Column(name = "event_name")
+    val eventName: String,
+
     @Enumerated(EnumType.STRING)
     val eventType: EventType,
+
+    @Column(name = "location")
     val location: String,
-    val eventImagePath: String?,
-    val displayEndDate: LocalDateTime,
+
+    @Column(name = "ticketing_start_datetime")
+    val ticketingStartDateTime: LocalDateTime,
+
+    @Column(name = "ticketing_end_datetime")
+    val ticketingEndDateTime: LocalDateTime,
+
+    @Column(name = "ticket_price")
     val ticketPrice: Int,
-) : BaseTimeEntity()
+
+    @Column(name = "total_ticket_count")
+    val totalTicketCount: Int,
+
+    @Embedded
+    val details: EventDetails,
+
+    @Column(name = "uket_event_image_id")
+    val uketEventImageId: String,
+
+    @Column(name = "thumbnail_image_id")
+    val thumbnailImageId: String,
+
+    @Convert(converter = ListToStringConverter::class)
+    @Column(name = "banner_image_ids")
+    val bannerImageIds: List<String>,
+
+    _uketEventRounds: List<UketEventRound>,
+) : BaseTimeEntity() {
+    @OneToMany(
+        mappedBy = "uketEvent",
+        fetch = FetchType.LAZY,
+        orphanRemoval = true,
+        cascade = [CascadeType.ALL],
+    )
+    val uketEventRounds: List<UketEventRound> = _uketEventRounds.map {
+        UketEventRound(
+            id = it.id,
+            uketEvent = this,
+            eventRoundDateTime = it.eventRoundDateTime
+        )
+    }
+
+    @Embeddable
+    data class EventDetails(
+        @Column(name = "information")
+        val information: String,
+        @Column(name = "caution")
+        val caution: String,
+        @Embedded
+        val contact: EventContact,
+    )
+
+    @Embeddable
+    data class EventContact(
+        @Column(name = "contact_type")
+        @Enumerated(EnumType.STRING)
+        val type: ContactType,
+        @Column(name = "contact_content")
+        val content: String,
+    ) {
+        enum class ContactType {
+            INSTAGRAM,
+            KAKAO,
+        }
+    }
+}

--- a/src/main/kotlin/domain/uketevent/entity/UketEventRound.kt
+++ b/src/main/kotlin/domain/uketevent/entity/UketEventRound.kt
@@ -21,7 +21,7 @@ class UketEventRound(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uket_event_id", nullable = false)
-    val uketEvent: UketEvent?,
+    var uketEvent: UketEvent?,
 
     @Column(name = "event_round_datetime")
     val eventRoundDateTime: LocalDateTime,

--- a/src/main/kotlin/domain/uketevent/entity/UketEventRound.kt
+++ b/src/main/kotlin/domain/uketevent/entity/UketEventRound.kt
@@ -1,6 +1,8 @@
 package uket.domain.uketevent.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -16,10 +18,11 @@ class UketEventRound(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
-    @ManyToOne
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uket_event_id", nullable = false)
-    val uketEvent: UketEvent,
-    val name: String,
-    val eventDate: LocalDateTime,
-    val ticketingDateTime: LocalDateTime,
+    val uketEvent: UketEvent?,
+
+    @Column(name = "event_round_datetime")
+    val eventRoundDateTime: LocalDateTime,
 ) : BaseTimeEntity()

--- a/src/main/kotlin/domain/uketevent/enums/TicketingStatus.kt
+++ b/src/main/kotlin/domain/uketevent/enums/TicketingStatus.kt
@@ -1,0 +1,7 @@
+package uket.domain.uketevent.enums
+
+enum class TicketingStatus {
+    티켓팅_진행중,
+    오픈_예정,
+    티켓팅_종료,
+}

--- a/src/main/kotlin/domain/uketevent/repository/UketEventRepository.kt
+++ b/src/main/kotlin/domain/uketevent/repository/UketEventRepository.kt
@@ -2,6 +2,7 @@ package uket.domain.uketevent.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import uket.common.enums.EventType
 import uket.domain.uketevent.entity.UketEvent
 
 interface UketEventRepository : JpaRepository<UketEvent, Long> {
@@ -14,4 +15,32 @@ interface UketEventRepository : JpaRepository<UketEvent, Long> {
         nativeQuery = true,
     )
     fun findOrganizationNameByUketEventId(uketEventId: Long): String?
+
+    @Query(
+        """
+            SELECT ue FROM UketEvent ue 
+            JOIN ue.uketEventRounds uer
+            WHERE ue.eventType = :eventType AND
+                (   
+                    SELECT MAX(uer.eventRoundDateTime)
+                    FROM UketEventRound uer
+                    WHERE uer.uketEvent = ue
+                ) >= CURRENT_TIMESTAMP
+        """
+    )
+    fun findAllByEventTypeAndEventEndDateBeforeNowWithUketEventRound(eventType: EventType): List<UketEvent>
+
+    @Query(
+        """
+            SELECT ue FROM UketEvent ue 
+            JOIN ue.uketEventRounds uer
+            WHERE
+                (   
+                    SELECT MAX(uer.eventRoundDateTime)
+                    FROM UketEventRound uer
+                    WHERE uer.uketEvent = ue
+                ) >= CURRENT_TIMESTAMP
+        """
+    )
+    fun findAllByEventEndDateBeforeNowWithUketEventRound(): List<UketEvent>
 }

--- a/src/main/kotlin/domain/uketevent/service/EntryGroupService.kt
+++ b/src/main/kotlin/domain/uketevent/service/EntryGroupService.kt
@@ -20,16 +20,16 @@ class EntryGroupService(
     fun findByUketEventRoundId(uketEventRoundId: Long): List<EntryGroup> =
         entryGroupRepository.findByUketEventRoundId(uketEventRoundId, EntryGroup::class.java)
 
-    @Transactional
-    fun increaseReservedCount(entryGroupId: Long) {
-        val entryGroup = this.getById(entryGroupId)
-        val isSuccess: Boolean = entryGroup.increaseReservedCount()
-
-        if (java.lang.Boolean.FALSE == isSuccess) {
-            throw IllegalStateException("해당 입장 그룹의 예매 가능 인원이 없습니다.")
-        }
-        entryGroupRepository.save(entryGroup)
-    }
+//    @Transactional
+//    fun increaseReservedCount(entryGroupId: Long) {
+//        val entryGroup = this.getById(entryGroupId)
+//        val isSuccess: Boolean = entryGroup.increaseReservedCount()
+//
+//        if (java.lang.Boolean.FALSE == isSuccess) {
+//            throw IllegalStateException("해당 입장 그룹의 예매 가능 인원이 없습니다.")
+//        }
+//        entryGroupRepository.save(entryGroup)
+//    }
 
     // @DistributedLock(key = "#reservationId")
     fun decreaseReservedCount(entryGroupId: Long) {

--- a/src/main/kotlin/domain/uketevent/service/UketEventRoundService.kt
+++ b/src/main/kotlin/domain/uketevent/service/UketEventRoundService.kt
@@ -22,9 +22,9 @@ class UketEventRoundService(
     fun findByUketEventId(uketEventId: Long): List<UketEventRound> =
         uketEventRoundRepository.findByUketEventId(uketEventId, UketEventRound::class.java)
 
-    fun getNameById(uketEventRoundId: Long): String {
-        val uketEventRound = this.getById(uketEventRoundId)
-        val name = uketEventRound.name
-        return name
-    }
+//    fun getNameById(uketEventRoundId: Long): String {
+//        val uketEventRound = this.getById(uketEventRoundId)
+//        val name = uketEventRound.name
+//        return name
+//    }
 }

--- a/src/main/kotlin/domain/uketevent/service/UketEventService.kt
+++ b/src/main/kotlin/domain/uketevent/service/UketEventService.kt
@@ -3,20 +3,63 @@ package uket.domain.uketevent.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uket.api.user.EventListQueryType
+import uket.common.enums.EventType
+import uket.domain.uketevent.dto.EventListItem
 import uket.domain.uketevent.entity.UketEvent
+import uket.domain.uketevent.enums.TicketingStatus
 import uket.domain.uketevent.repository.UketEventRepository
+import java.time.LocalDateTime
 
 @Service
-@Transactional(readOnly = true)
 class UketEventService(
     private val uketEventRepository: UketEventRepository,
 ) {
+    @Transactional(readOnly = true)
     fun getById(uketEventId: Long): UketEvent {
         val uketEvent = uketEventRepository.findByIdOrNull(uketEventId)
             ?: throw IllegalStateException("해당 행사를 찾을 수 없습니다.")
         return uketEvent
     }
 
+    @Transactional(readOnly = true)
+    fun getActiveEventItemList(type: EventListQueryType): List<EventListItem> {
+        lateinit var eventList: List<UketEvent>
+        if (type.name.equals("ALL")) {
+            eventList = uketEventRepository.findAllByEventEndDateBeforeNowWithUketEventRound()
+        } else {
+            eventList = uketEventRepository.findAllByEventTypeAndEventEndDateBeforeNowWithUketEventRound(EventType.valueOf(type.name))
+        }
+
+        val now = LocalDateTime.now()
+        val itemList = eventList
+            .map {
+                var ticketingStatus = TicketingStatus.오픈_예정
+                if (it.ticketingStartDateTime.isAfter(now)) {
+                    ticketingStatus = TicketingStatus.티켓팅_진행중
+                }
+                if (it.ticketingEndDateTime.isAfter(now)) {
+                    ticketingStatus = TicketingStatus.티켓팅_종료
+                }
+
+                EventListItem(
+                    eventName = it.eventName,
+                    eventThumbnailImagePath = it.thumbnailImageId,
+                    eventStartDate = it.uketEventRounds.minOf { it.eventRoundDateTime },
+                    eventEndDate = it.uketEventRounds.maxOf { it.eventRoundDateTime },
+                    ticketingStartDate = it.ticketingStartDateTime,
+                    ticketingEndDate = it.ticketingEndDateTime,
+                    ticketingStatus = ticketingStatus
+                )
+            }
+        val orderedList = itemList.sortedWith(
+            compareBy<EventListItem> { it.ticketingStatus }
+                .thenBy { it.eventStartDate }
+        )
+        return orderedList
+    }
+
+    @Transactional(readOnly = true)
     fun getOrganizationNameByUketEventIid(uketEventId: Long): String {
         val name = uketEventRepository.findOrganizationNameByUketEventId(uketEventId)
             ?: throw IllegalStateException("해당 행사의 이름을 찾을 수 없습니다.")

--- a/src/main/kotlin/domain/uketevent/service/UketEventService.kt
+++ b/src/main/kotlin/domain/uketevent/service/UketEventService.kt
@@ -30,15 +30,16 @@ class UketEventService(
         } else {
             eventList = uketEventRepository.findAllByEventTypeAndEventEndDateBeforeNowWithUketEventRound(EventType.valueOf(type.name))
         }
+        println(eventList.map { it.eventName })
 
         val now = LocalDateTime.now()
         val itemList = eventList
             .map {
                 var ticketingStatus = TicketingStatus.오픈_예정
-                if (it.ticketingStartDateTime.isAfter(now)) {
+                if (now.isAfter(it.ticketingStartDateTime)) {
                     ticketingStatus = TicketingStatus.티켓팅_진행중
                 }
-                if (it.ticketingEndDateTime.isAfter(now)) {
+                if (now.isAfter(it.ticketingEndDateTime)) {
                     ticketingStatus = TicketingStatus.티켓팅_종료
                 }
 
@@ -52,10 +53,12 @@ class UketEventService(
                     ticketingStatus = ticketingStatus
                 )
             }
+        println(itemList.map { it.eventName + it.ticketingStatus })
         val orderedList = itemList.sortedWith(
             compareBy<EventListItem> { it.ticketingStatus }
                 .thenBy { it.eventStartDate }
         )
+        println(orderedList.map { it.eventName + it.ticketingStatus })
         return orderedList
     }
 

--- a/src/test/kotlin/uket/domain/DomainEntityTest.kt
+++ b/src/test/kotlin/uket/domain/DomainEntityTest.kt
@@ -35,7 +35,17 @@ class DomainEntityTest {
     @DisplayName("테스트 디비와 연동이 잘 되는 지 확인")
     fun testDBIntegration() {
         // given
-        val user = User(0L, Platform.KAKAO, "platformIdA", "nameA", "emailA", "profileImageA", "depositorNameA", "phoneNumberA", true)
+        val user = User(
+            0L,
+            Platform.KAKAO,
+            "platformIdA",
+            "nameA",
+            "emailA",
+            "profileImageA",
+            "depositorNameA",
+            "phoneNumberA",
+            true
+        )
         em.persist(user)
 
         // when
@@ -49,13 +59,24 @@ class DomainEntityTest {
     @DisplayName("각 엔티티 생성 및 조회 테스트(누락 필드 확인)")
     fun test() {
         // given
-        val user = User(0L, Platform.KAKAO, "platformIdA", "nameA", "emailA", "profileImageA", "depositorNameA", "phoneNumberA", true)
+        val user = User(
+            0L,
+            Platform.KAKAO,
+            "platformIdA",
+            "nameA",
+            "emailA",
+            "profileImageA",
+            "depositorNameA",
+            "phoneNumberA",
+            true
+        )
 
         val organization = Organization(0L, "OrganiationA", null)
         val admin = Admin(0L, organization, "nameA", "emailA", "password123", true)
 
         val payment = Payment(0L, 0L, "123-12-123457", "linkA")
-        val paymentHistory = PaymentHistory(0L, 0L, 0L, 0, PaymentStatus.PURCHASED, "categoryA", PaymentManner.DEPOSIT_LINK, null)
+        val paymentHistory =
+            PaymentHistory(0L, 0L, 0L, 0, PaymentStatus.PURCHASED, "categoryA", PaymentManner.DEPOSIT_LINK, null)
 
         val ticket = Ticket(0L, 0L, 0L, TicketStatus.BEFORE_ENTER, "123456789", null)
 
@@ -63,9 +84,27 @@ class DomainEntityTest {
         val terms = Terms(0L, "nameA", TermsType.MANDATORY, 0L, true)
         val termSign = TermSign(0L, 0L, 0L, true, LocalDateTime.now())
 
-        val uketEvent = UketEvent(0L, 0L, "nameA", EventType.FESTIVAL, "00시00구", null, LocalDateTime.now(), 0)
-        val uketEventRound = UketEventRound(0L, uketEvent, "nameA", LocalDateTime.now(), LocalDateTime.now())
-        val entryGroup = EntryGroup(0L, uketEventRound, "nameA", LocalDateTime.now(), LocalDateTime.now(), 0, 100)
+        val uketEventRound = UketEventRound(0L, null, LocalDateTime.now())
+        val uketEvent = UketEvent(
+            id = 0L,
+            organizationId = 0L,
+            eventName = "nameA",
+            eventType = EventType.FESTIVAL,
+            location = "00시00구",
+            ticketingStartDateTime = LocalDateTime.now(),
+            ticketingEndDateTime = LocalDateTime.now(),
+            ticketPrice = 0,
+            totalTicketCount = 0,
+            details = UketEvent.EventDetails(
+                "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
+            ),
+            uketEventImageId = "",
+            thumbnailImageId = "",
+            bannerImageIds = listOf(),
+            _uketEventRounds = listOf(uketEventRound)
+        )
+        uketEventRound.uketEvent = uketEvent
+        val entryGroup = EntryGroup(0L, uketEventRound, "nameA", LocalDateTime.now(), LocalDateTime.now(), 0)
 
         // when
         em.persist(user)

--- a/src/test/kotlin/uket/domain/reservation/TicketRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/reservation/TicketRepositoryTest.kt
@@ -32,31 +32,37 @@ class TicketRepositoryTest(
         beforeEach {
             val uketEvent = UketEvent(
                 organizationId = 1L,
-                name = "uketEventA",
+                eventName = "uketEventA",
                 eventType = EventType.FESTIVAL,
-                location = "locationA",
-                eventImagePath = null,
-                displayEndDate = LocalDateTime.now(),
-                ticketPrice = 1000,
+                location = "00시00구",
+                ticketingStartDateTime = LocalDateTime.now(),
+                ticketingEndDateTime = LocalDateTime.now(),
+                ticketPrice = 0,
+                totalTicketCount = 0,
+                details = UketEvent.EventDetails(
+                    "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
+                ),
+                uketEventImageId = "",
+                thumbnailImageId = "",
+                bannerImageIds = listOf(),
+                _uketEventRounds = listOf()
             )
             entityManager.persist(uketEvent)
 
             val uketEventRound = UketEventRound(
                 uketEvent = uketEvent,
-                name = "uketEventRoundA",
-                eventDate = LocalDateTime.now(),
-                ticketingDateTime = LocalDateTime.now(),
+                eventRoundDateTime = LocalDateTime.now()
             )
             entityManager.persist(uketEventRound)
+            uketEvent.addUketEventRound(uketEventRound)
 
             // 엔트리 그룹 저장
             val entryGroup = EntryGroup(
                 uketEventRound = uketEventRound,
-                name = "entryGroupA",
-                entryStartTime = LocalDateTime.now(),
-                entryEndTime = LocalDateTime.now(),
-                reservationCount = 0,
-                totalCount = 10,
+                entryGroupName = "nameA",
+                entryStartDateTime = LocalDateTime.now(),
+                entryEndDateTime = LocalDateTime.now(),
+                ticketCount = 0,
             )
             entityManager.persist(entryGroup)
 

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
@@ -1,0 +1,42 @@
+package uket.domain.uketEvent
+
+import org.jeasy.random.EasyRandom
+import org.jeasy.random.EasyRandomParameters
+import org.jeasy.random.FieldPredicates.named
+import uket.domain.uketevent.entity.UketEvent
+import uket.domain.uketevent.entity.UketEventRound
+import java.time.LocalDateTime
+
+class UketEventRandomUtil {
+    companion object {
+        fun createUketEventWithDates(ticketingStartDateTime: LocalDateTime, ticketingEndDateTime: LocalDateTime): UketEvent {
+            val easyRandom = EasyRandom(
+                EasyRandomParameters()
+                    .randomize(named("id")) {
+                        0L
+                    }.randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
+                    .randomize(named("ticketingEndDateTime")) { ticketingEndDateTime }
+                    .randomize(named("uketEventRounds")) { listOf<UketEvent>() }
+            )
+            val uketEvent = easyRandom.nextObject(UketEvent::class.java)
+
+            return uketEvent
+        }
+
+        fun createUketEventsRoundWithDate(uketEvent: UketEvent, uketEventRoundDates: List<LocalDateTime>): List<UketEventRound> {
+            val eventRounds = uketEventRoundDates.map {
+                val easyRandomEventRound = EasyRandom(
+                    EasyRandomParameters()
+                        .randomize(named("id")) { 0L }
+                        .randomize(named("eventRoundDateTime")) { it }
+                )
+                easyRandomEventRound.nextObject(UketEventRound::class.java)
+            }
+
+            eventRounds.forEach { uketEvent.addUketEventRound(it) }
+            println("uketEventRounds : ${uketEvent.uketEventRounds}")
+
+            return eventRounds
+        }
+    }
+}

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
@@ -6,6 +6,7 @@ import org.jeasy.random.FieldPredicates.named
 import uket.domain.uketevent.entity.UketEvent
 import uket.domain.uketevent.entity.UketEventRound
 import java.time.LocalDateTime
+import kotlin.random.Random
 
 class UketEventRandomUtil {
     companion object {
@@ -17,6 +18,23 @@ class UketEventRandomUtil {
                     }.randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
                     .randomize(named("ticketingEndDateTime")) { ticketingEndDateTime }
                     .randomize(named("uketEventRounds")) { listOf<UketEvent>() }
+            )
+            val uketEvent = easyRandom.nextObject(UketEvent::class.java)
+
+            return uketEvent
+        }
+
+        fun createUketEventWithDatesAndNameAndId(ticketingStartDateTime: LocalDateTime, ticketingEndDateTime: LocalDateTime, eventName: String, id: Long): UketEvent {
+            val easyRandom = EasyRandom(
+                EasyRandomParameters()
+                    .randomize(named("id")) {
+                        id
+                    }.randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
+                    .randomize(named("ticketingEndDateTime")) { ticketingEndDateTime }
+                    .randomize(named("uketEventRounds")) { listOf<UketEvent>() }
+                    .randomize(named("eventName")) {
+                        eventName
+                    }
             )
             val uketEvent = easyRandom.nextObject(UketEvent::class.java)
 
@@ -37,6 +55,129 @@ class UketEventRandomUtil {
             println("uketEventRounds : ${uketEvent.uketEventRounds}")
 
             return eventRounds
+        }
+
+        fun createDummyData() {
+            val now = LocalDateTime.now()
+            val events = mutableListOf<UketEvent>()
+            val rounds = mutableListOf<UketEventRound>()
+
+            repeat(100) { i ->
+                val ticketingStart = now.plusDays(Random.nextLong(-10, 10))
+                val ticketingEnd = now.plusDays(Random.nextLong(0, 3))
+                val event = createUketEventWithDatesAndNameAndId(ticketingStart, ticketingEnd, "행사$i", i.toLong() + 1)
+                events.add(event)
+
+                val roundDate = ticketingEnd.plusDays(Random.nextLong(1, 30))
+                val roundSize = Random.nextInt(1, 3)
+                val roundList = mutableListOf<LocalDateTime>()
+                repeat(roundSize) { s ->
+                    roundList.add(roundDate.plusDays(s.toLong()))
+                }
+                val uketEventRounds = createUketEventsRoundWithDate(event, roundList)
+                uketEventRounds.forEach { r -> event.addUketEventRound(r) }
+                rounds.addAll(uketEventRounds)
+            }
+
+            println("-- Insert Events")
+            events.forEach {
+                println(toInsertSqlForUketEvent(it))
+            }
+
+            println("-- Insert Event Rounds")
+            rounds.forEach {
+                println(toInsertSqlForUketEventRound(it))
+            }
+        }
+
+        fun toInsertSqlForUketEventRound(uketEventRound: UketEventRound): String {
+            val tableName = "uket_event_round"
+
+            val columns = mutableListOf<String>()
+            val values = mutableListOf<String>()
+
+            // 직접 필드 접근 (중첩 필드도 분해해서 처리)
+            with(uketEventRound) {
+                // 일반 필드
+                columns += listOf(
+                    "uket_event_id",
+                    "event_round_datetime",
+                    "created_at",
+                    "updated_at"
+                )
+
+                values += listOf(
+                    uketEvent!!.id,
+                    eventRoundDateTime,
+                    createdAt,
+                    updatedAt
+                ).map { toSqlValue(it) }
+            }
+
+            return "INSERT INTO $tableName (${columns.joinToString(", ")}) VALUES (${values.joinToString(", ")});"
+        }
+
+        fun toInsertSqlForUketEvent(event: UketEvent): String {
+            val tableName = "uket_event"
+
+            val columns = mutableListOf<String>()
+            val values = mutableListOf<String>()
+
+            // 직접 필드 접근 (중첩 필드도 분해해서 처리)
+            with(event) {
+                // 일반 필드
+                columns += listOf(
+                    "organization_id",
+                    "event_name",
+                    "event_type",
+                    "location",
+                    "ticketing_start_datetime",
+                    "ticketing_end_datetime",
+                    "ticket_price",
+                    "total_ticket_count",
+                    "uket_event_image_id",
+                    "thumbnail_image_id",
+                    "banner_image_ids",
+                    "created_at",
+                    "updated_at"
+                )
+
+                values += listOf(
+                    organizationId,
+                    eventName,
+                    eventType.name,
+                    location,
+                    ticketingStartDateTime,
+                    ticketingEndDateTime,
+                    ticketPrice,
+                    totalTicketCount,
+                    uketEventImageId,
+                    thumbnailImageId,
+                    bannerImageIds.joinToString(","),
+                    createdAt,
+                    updatedAt
+                ).map { toSqlValue(it) }
+
+                // Embedded: EventDetails -> information, caution, contact_type, contact_content
+                columns += listOf("information", "caution", "contact_type", "contact_content")
+                values += listOf(
+                    details.information,
+                    details.caution,
+                    details.contact.type.name,
+                    details.contact.content
+                ).map { toSqlValue(it) }
+            }
+
+            return "INSERT INTO $tableName (${columns.joinToString(", ")}) VALUES (${values.joinToString(", ")});"
+        }
+
+        fun toSqlValue(value: Any?): String = when (value) {
+            null -> "NULL"
+            is String -> "'${value.replace("'", "''")}'"
+            is Enum<*> -> "'${value.name}'"
+            is LocalDateTime -> "'$value'"
+            is Boolean -> if (value) "1" else "0"
+            else -> value.toString()
         }
     }
 }

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
@@ -37,12 +37,20 @@ class UketEventRepositoryTest(
 
             val uketEvent = UketEvent(
                 organizationId = organization.id,
-                name = "uketEventA",
+                eventName = "uketEventA",
                 eventType = EventType.FESTIVAL,
                 location = "locationA",
-                eventImagePath = null,
-                displayEndDate = LocalDateTime.now(),
                 ticketPrice = 1000,
+                ticketingStartDateTime = LocalDateTime.now(),
+                ticketingEndDateTime = LocalDateTime.now(),
+                totalTicketCount = 0,
+                details = UketEvent.EventDetails(
+                    "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
+                ),
+                uketEventImageId = "",
+                thumbnailImageId = "",
+                bannerImageIds = listOf(),
+                _uketEventRounds = listOf()
             )
             entityManager.persist(uketEvent)
             entityManager.flush()

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
@@ -7,7 +7,6 @@ import io.kotest.extensions.spring.SpringExtension
 import io.kotest.matchers.shouldBe
 import jakarta.persistence.EntityManager
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
-import org.springframework.transaction.annotation.Transactional
 import uket.common.enums.EventType
 import uket.domain.admin.entity.Organization
 import uket.domain.uketevent.entity.UketEvent
@@ -15,7 +14,6 @@ import uket.domain.uketevent.repository.UketEventRepository
 import java.time.LocalDateTime
 
 @DataJpaTest
-@Transactional
 class UketEventRepositoryTest(
     private val uketEventRepository: UketEventRepository,
     private val entityManager: EntityManager,
@@ -23,55 +21,146 @@ class UketEventRepositoryTest(
 
         isolationMode = IsolationMode.InstancePerTest
 
-        lateinit var savedOrganization: Organization
-        lateinit var savedUketEvent: UketEvent
-
-        beforeEach {
-            val organization = Organization(
-                name = "organizationA",
-                organizationImagePath = null,
-            )
-            entityManager.persist(organization)
-            entityManager.flush()
-            savedOrganization = organization
-
-            val uketEvent = UketEvent(
-                organizationId = organization.id,
-                eventName = "uketEventA",
-                eventType = EventType.FESTIVAL,
-                location = "locationA",
-                ticketPrice = 1000,
-                ticketingStartDateTime = LocalDateTime.now(),
-                ticketingEndDateTime = LocalDateTime.now(),
-                totalTicketCount = 0,
-                details = UketEvent.EventDetails(
-                    "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
-                ),
-                uketEventImageId = "",
-                thumbnailImageId = "",
-                bannerImageIds = listOf(),
-                _uketEventRounds = listOf()
-            )
-            entityManager.persist(uketEvent)
-            entityManager.flush()
-            savedUketEvent = uketEvent
-
-            entityManager.clear()
-        }
-
         describe("findOrganizationNameByUketEventId") {
-            it("정상적으로 단체 이름 조회") {
-                val name = uketEventRepository.findOrganizationNameByUketEventId(uketEventId = savedUketEvent.id)
-                name shouldBe "organizationA"
-            }
+            context("단체와 이벤트가 연결되어 있을 때") {
+                it("정상적으로 단체 이름 조회") {
+                    val uketEventId = setDB(entityManager)
+                    val name = uketEventRepository.findOrganizationNameByUketEventId(uketEventId = uketEventId)
+                    name shouldBe "organizationA"
+                }
 
-            it("조건에 맞는 단체가 없는 경우") {
-                val name = uketEventRepository.findOrganizationNameByUketEventId(uketEventId = 999L)
-                name shouldBe null
+                it("조건에 맞는 단체가 없는 경우") {
+                    setDB(entityManager)
+                    val name = uketEventRepository.findOrganizationNameByUketEventId(uketEventId = 999L)
+                    name shouldBe null
+                }
             }
         }
-    }) {
+
+        describe("findAllByEventEndDateBeforeNowWithUketEventRound") {
+            context("티켓팅 중인 이벤트 3개가 있는 경우") {
+                it("3개의 이벤트 조회") {
+                    setDB2(entityManager)
+
+                    val eventList = uketEventRepository.findAllByEventEndDateBeforeNowWithUketEventRound()
+                    eventList.size shouldBe 3
+                }
+            }
+
+            context("티켓팅 중인 이벤트 2개, 행사가 종료된 이벤트 1개가 있는 경우") {
+                it("조건에 맞는 단체가 없는 경우") {
+                    setDB3(entityManager)
+
+                    val eventList = uketEventRepository.findAllByEventEndDateBeforeNowWithUketEventRound()
+                    eventList.size shouldBe 2
+                }
+            }
+        }
+    }
+    ) {
     override fun extensions(): List<Extension> {
         return super.extensions() + listOf(SpringExtension) // SpringExtension 활성화
     }
+}
+
+private fun setDB3(entityManager: EntityManager) {
+    val now = LocalDateTime.now()
+    val uketEvent1 =
+        UketEventRandomUtil.createUketEventWithDates(
+            now.minusDays(2),
+            now.plusDays(2)
+        )
+    entityManager.persist(uketEvent1)
+    val uketEventRounds1 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+    uketEventRounds1.forEach { entityManager.persist(it) }
+
+    val uketEvent2 =
+        UketEventRandomUtil.createUketEventWithDates(
+            now.minusDays(3),
+            now.plusDays(3)
+        )
+    entityManager.persist(uketEvent2)
+    val uketEventRounds2 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+    uketEventRounds2.forEach { entityManager.persist(it) }
+
+    val closedEvent = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(4),
+        now.minusDays(3)
+    )
+    entityManager.persist(closedEvent)
+    val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundWithDate(
+        closedEvent,
+        listOf(now.minusDays(2), now.minusDays(1))
+    )
+    uketEventRounds3.forEach { entityManager.persist(it) }
+
+    entityManager.flush()
+}
+
+private fun setDB2(entityManager: EntityManager) {
+    val now = LocalDateTime.now()
+    val uketEvent1 =
+        UketEventRandomUtil.createUketEventWithDates(
+            now.minusDays(2),
+            now.plusDays(2)
+        )
+
+    entityManager.persist(uketEvent1)
+    val uketEventRounds1 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+    uketEventRounds1.forEach { entityManager.persist(it) }
+
+    val uketEvent2 =
+        UketEventRandomUtil.createUketEventWithDates(
+            now.minusDays(3),
+            now.plusDays(3)
+        )
+    entityManager.persist(uketEvent2)
+    val uketEventRounds2 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+    uketEventRounds2.forEach { entityManager.persist(it) }
+
+    val uketEvent3 =
+        UketEventRandomUtil.createUketEventWithDates(
+            now.minusDays(4),
+            now.plusDays(4)
+        )
+    entityManager.persist(uketEvent3)
+    val uketEventRounds3 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent3, listOf(now, now.plusDays(1)))
+    uketEventRounds3.forEach { entityManager.persist(it) }
+
+    entityManager.flush()
+}
+
+private fun setDB(entityManager: EntityManager): Long {
+    val organization = Organization(
+        name = "organizationA",
+        organizationImagePath = null,
+    )
+    entityManager.persist(organization)
+
+    val uketEvent = UketEvent(
+        organizationId = organization.id,
+        eventName = "uketEventA",
+        eventType = EventType.FESTIVAL,
+        location = "locationA",
+        ticketPrice = 1000,
+        ticketingStartDateTime = LocalDateTime.now(),
+        ticketingEndDateTime = LocalDateTime.now(),
+        totalTicketCount = 0,
+        details = UketEvent.EventDetails(
+            "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
+        ),
+        uketEventImageId = "",
+        thumbnailImageId = "",
+        bannerImageIds = listOf(),
+        _uketEventRounds = listOf()
+    )
+    entityManager.persist(uketEvent)
+    entityManager.flush()
+
+    return uketEvent.id
 }

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
@@ -72,7 +72,7 @@ private fun setDB3(entityManager: EntityManager) {
         )
     entityManager.persist(uketEvent1)
     val uketEventRounds1 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now.plusDays(6), now.plusDays(7)))
     uketEventRounds1.forEach { entityManager.persist(it) }
 
     val uketEvent2 =
@@ -82,7 +82,7 @@ private fun setDB3(entityManager: EntityManager) {
         )
     entityManager.persist(uketEvent2)
     val uketEventRounds2 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now.plusDays(8)))
     uketEventRounds2.forEach { entityManager.persist(it) }
 
     val closedEvent = UketEventRandomUtil.createUketEventWithDates(
@@ -109,7 +109,7 @@ private fun setDB2(entityManager: EntityManager) {
 
     entityManager.persist(uketEvent1)
     val uketEventRounds1 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now.plusDays(3), now.plusDays(4)))
     uketEventRounds1.forEach { entityManager.persist(it) }
 
     val uketEvent2 =
@@ -119,7 +119,7 @@ private fun setDB2(entityManager: EntityManager) {
         )
     entityManager.persist(uketEvent2)
     val uketEventRounds2 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now.plusDays(7), now.plusDays(8)))
     uketEventRounds2.forEach { entityManager.persist(it) }
 
     val uketEvent3 =
@@ -129,7 +129,7 @@ private fun setDB2(entityManager: EntityManager) {
         )
     entityManager.persist(uketEvent3)
     val uketEventRounds3 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent3, listOf(now, now.plusDays(1)))
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent3, listOf(now.plusDays(5)))
     uketEventRounds3.forEach { entityManager.persist(it) }
 
     entityManager.flush()

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
@@ -1,0 +1,116 @@
+package uket.domain.uketEvent
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import uket.api.user.EventListQueryType
+import uket.domain.uketevent.entity.UketEvent
+import uket.domain.uketevent.repository.UketEventRepository
+import uket.domain.uketevent.service.UketEventService
+import java.time.LocalDateTime
+
+class UketEventServiceTest :
+    DescribeSpec({
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val uketEventRepository: UketEventRepository = mockk<UketEventRepository>()
+        val uketEventService: UketEventService = UketEventService(uketEventRepository)
+
+        describe("유효한 행사 목록 조회") {
+            context("티켓팅 진행 중인 행사 3개가 있을 때") {
+                val (uketEvent1, uketEvent2, uketEvent3) = setDB(uketEventRepository)
+                every { uketEventRepository.findAllByEventEndDateBeforeNowWithUketEventRound() } returns listOf(
+                    uketEvent1,
+                    uketEvent2,
+                    uketEvent3
+                )
+
+                it("행사 시작 순서대로 출력") {
+                    val eventList = uketEventService.getActiveEventItemList(EventListQueryType.ALL)
+                    eventList.size shouldBe 3
+                    eventList.get(0).eventName shouldBe uketEvent3.eventName
+                    eventList.get(1).eventName shouldBe uketEvent2.eventName
+                    eventList.get(2).eventName shouldBe uketEvent1.eventName
+                }
+            }
+            context("티켓팅 진행 중인 행사 2개, 티켓팅 시작 전인 행사 1개, 티켓팅 종료된 행사 1개가 있을 때") {
+                val now = LocalDateTime.now()
+                val (uketEvent1, uketEvent2) = setDB2(now)
+                val (notOpenedEvent, closedEvent) = setDB3(now, uketEvent2)
+
+                every { uketEventRepository.findAllByEventEndDateBeforeNowWithUketEventRound() } returns listOf(
+                    uketEvent1,
+                    uketEvent2,
+                    notOpenedEvent,
+                    closedEvent
+                )
+
+                it("티켓팅 진행 중, 시작 전, 종료 순으로 출력") {
+                    val eventList = uketEventService.getActiveEventItemList(EventListQueryType.ALL)
+                    eventList.size shouldBe 4
+                    eventList.get(0).eventName shouldBe uketEvent2.eventName
+                    eventList.get(1).eventName shouldBe uketEvent1.eventName
+                    eventList.get(2).eventName shouldBe notOpenedEvent.eventName
+                    eventList.get(3).eventName shouldBe closedEvent.eventName
+                }
+            }
+        }
+    })
+
+private fun setDB3(
+    now: LocalDateTime,
+    uketEvent2: UketEvent,
+): Pair<UketEvent, UketEvent> {
+    val notOpenedEvent = UketEventRandomUtil.createUketEventWithDates(
+        now.plusDays(3),
+        now.plusDays(5)
+    )
+    val uketEventRounds3 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now.plusDays(7), now.plusDays(8)))
+
+    val closedEvent = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(4),
+        now.minusDays(3)
+    )
+    val uketEventRounds4 =
+        UketEventRandomUtil.createUketEventsRoundWithDate(closedEvent, listOf(now.minusDays(2), now.plusDays(1)))
+    return Pair(notOpenedEvent, closedEvent)
+}
+
+private fun setDB(uketEventRepository: UketEventRepository): Triple<UketEvent, UketEvent, UketEvent> {
+    val now = LocalDateTime.now()
+    val uketEvent1 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(2),
+        now.plusDays(2)
+    )
+    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+    val uketEvent2 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(3),
+        now.plusDays(3)
+    )
+    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+    val uketEvent3 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(4),
+        now.plusDays(4)
+    )
+    val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent3, listOf(now, now.plusDays(1)))
+    return Triple(uketEvent1, uketEvent2, uketEvent3)
+}
+
+private fun setDB2(now: LocalDateTime): Pair<UketEvent, UketEvent> {
+    val uketEvent1 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(2),
+        now.plusDays(2)
+    )
+    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+
+    val uketEvent2 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(3),
+        now.plusDays(3)
+    )
+    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+    return Pair(uketEvent1, uketEvent2)
+}

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
@@ -32,8 +32,8 @@ class UketEventServiceTest :
                     val eventList = uketEventService.getActiveEventItemList(EventListQueryType.ALL)
                     eventList.size shouldBe 3
                     eventList.get(0).eventName shouldBe uketEvent3.eventName
-                    eventList.get(1).eventName shouldBe uketEvent2.eventName
-                    eventList.get(2).eventName shouldBe uketEvent1.eventName
+                    eventList.get(1).eventName shouldBe uketEvent1.eventName
+                    eventList.get(2).eventName shouldBe uketEvent2.eventName
                 }
             }
             context("티켓팅 진행 중인 행사 2개, 티켓팅 시작 전인 행사 1개, 티켓팅 종료된 행사 1개가 있을 때") {
@@ -69,7 +69,7 @@ private fun setDB3(
         now.plusDays(5)
     )
     val uketEventRounds3 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now.plusDays(7), now.plusDays(8)))
+        UketEventRandomUtil.createUketEventsRoundWithDate(notOpenedEvent, listOf(now.plusDays(7), now.plusDays(8)))
 
     val closedEvent = UketEventRandomUtil.createUketEventWithDates(
         now.minusDays(4),
@@ -80,37 +80,37 @@ private fun setDB3(
     return Pair(notOpenedEvent, closedEvent)
 }
 
+private fun setDB2(now: LocalDateTime): Pair<UketEvent, UketEvent> {
+    val uketEvent1 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(2),
+        now.plusDays(2)
+    )
+    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now.plusDays(5), now.plusDays(6)))
+
+    val uketEvent2 = UketEventRandomUtil.createUketEventWithDates(
+        now.minusDays(3),
+        now.plusDays(3)
+    )
+    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now.plusDays(7), now.plusDays(8)))
+    return Pair(uketEvent1, uketEvent2)
+}
+
 private fun setDB(uketEventRepository: UketEventRepository): Triple<UketEvent, UketEvent, UketEvent> {
     val now = LocalDateTime.now()
     val uketEvent1 = UketEventRandomUtil.createUketEventWithDates(
         now.minusDays(2),
         now.plusDays(2)
     )
-    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
+    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now.plusDays(7), now.plusDays(8)))
     val uketEvent2 = UketEventRandomUtil.createUketEventWithDates(
         now.minusDays(3),
         now.plusDays(3)
     )
-    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
+    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now.plusDays(9), now.plusDays(10)))
     val uketEvent3 = UketEventRandomUtil.createUketEventWithDates(
         now.minusDays(4),
         now.plusDays(4)
     )
-    val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent3, listOf(now, now.plusDays(1)))
+    val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent3, listOf(now.plusDays(5), now.plusDays(6)))
     return Triple(uketEvent1, uketEvent2, uketEvent3)
-}
-
-private fun setDB2(now: LocalDateTime): Pair<UketEvent, UketEvent> {
-    val uketEvent1 = UketEventRandomUtil.createUketEventWithDates(
-        now.minusDays(2),
-        now.plusDays(2)
-    )
-    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent1, listOf(now, now.plusDays(1)))
-
-    val uketEvent2 = UketEventRandomUtil.createUketEventWithDates(
-        now.minusDays(3),
-        now.plusDays(3)
-    )
-    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(uketEvent2, listOf(now, now.plusDays(1)))
-    return Pair(uketEvent1, uketEvent2)
 }

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
@@ -58,6 +58,10 @@ class UketEventServiceTest :
                 }
             }
         }
+
+        it("더미 sql 생성") {
+            UketEventRandomUtil.createDummyData()
+        }
     })
 
 private fun setDB3(


### PR DESCRIPTION
# 📌 개요
- 행사 목록 조회 API를 마이그레이션 하면서 추가된 요구사항들도 반영했습니다.

# 💻 작업사항
- [x] GET /uket-events API 스펙 정의 및 security, auth 설정
- [x] getActiveEventItemList 메서드 작성(종료 되지 않은 행사를 쿼리한 뒤, 코틀린으로 정렬)
- [x] 테스트 작성
단위 테스트가 아닌 테스트들의 결과
정렬 테스트<br>
[ddl](https://www.notion.so/25-03-30-1d49a71925b480a49906db5957092ab5?pvs=4#1db9a71925b480f487d5dcd60781fea0)<br>
결과<br>
![image.png](attachment:4818da1a-2683-4c9c-ad84-fa42a5a7cfdf:image.png)<br>
<br>
성능 테스트<br>
uketEvent 100개, uketEventRound 각 1~3개<br>
[ddl](https://www.notion.so/25-03-30-1d49a71925b480a49906db5957092ab5?pvs=4#1db9a71925b480abb4cde98779d34e49)<br>
결과<br>
![image.png](attachment:1b48fcbd-b6c2-43a3-b72f-0cf4a830e326:image.png)
![image.png](attachment:8c5a45f0-9898-43bb-8616-902ffde4f298:image.png)
![image](https://github.com/user-attachments/assets/fce56f85-9b38-4024-a6d4-d0d242468f75)

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- eventRegistration 도메인과 유사하게 수정했습니다. 도메인 수정을 잘 했는지 확인 부탁드립니다!
