### PR TITLE
[UKET-104] 일반 유저 회원가입(정보등록) API migration

### DIFF
--- a/src/main/kotlin/api/user/EventController.kt
+++ b/src/main/kotlin/api/user/EventController.kt
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uket.api.user.request.EventListQueryType
 import uket.api.user.response.ActiveEventsResponse
 import uket.domain.uketevent.service.UketEventService
 

--- a/src/main/kotlin/api/user/UserController.kt
+++ b/src/main/kotlin/api/user/UserController.kt
@@ -57,6 +57,7 @@ class UserController(
         @Parameter(hidden = true)
         @LoginUserId
         userId: Long,
+        @RequestBody
         request: UserRegisterRequest,
     ): ResponseEntity<AuthResponse> {
         val registerUserCommand = RegisterUserCommand(

--- a/src/main/kotlin/api/user/UserController.kt
+++ b/src/main/kotlin/api/user/UserController.kt
@@ -52,6 +52,7 @@ class UserController(
         return ResponseEntity.ok(response)
     }
 
+    @Operation(summary = "유저 회원가입", description = "유저의 추가 정보를 등록하고 회원가입을 완료합니다")
     @PostMapping("/users/register")
     fun register(
         @Parameter(hidden = true)

--- a/src/main/kotlin/api/user/UserController.kt
+++ b/src/main/kotlin/api/user/UserController.kt
@@ -1,6 +1,7 @@
 package uket.api.user
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -8,16 +9,19 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import uket.api.user.request.LoginRequest
 import uket.api.user.request.TokenReissueRequest
+import uket.api.user.request.UserRegisterRequest
 import uket.api.user.response.AuthResponse
 import uket.api.user.response.UserTokenResponse
+import uket.auth.config.adminId.LoginUserId
 import uket.auth.dto.UserAuthToken
 import uket.auth.jwt.JwtAuthTokenUtil
+import uket.domain.user.dto.RegisterUserCommand
 import uket.domain.user.enums.Platform
 import uket.domain.user.service.UserService
 import uket.facade.UserAuthFacade
 
 @RestController
-class AuthController(
+class UserController(
     private val userAuthFacade: UserAuthFacade,
     private val jwtAuthTokenUtil: JwtAuthTokenUtil,
     private val userService: UserService,
@@ -45,6 +49,26 @@ class AuthController(
     ): ResponseEntity<UserTokenResponse> {
         val authToken: UserAuthToken = userAuthFacade.reissue(request.accessToken, request.refreshToken)
         val response: UserTokenResponse = UserTokenResponse.from(authToken)
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/users/register")
+    fun register(
+        @Parameter(hidden = true)
+        @LoginUserId
+        userId: Long,
+        request: UserRegisterRequest,
+    ): ResponseEntity<AuthResponse> {
+        val registerUserCommand = RegisterUserCommand(
+            userId = userId,
+            depositorName = request.depositorName,
+            phoneNumber = request.phoneNumber
+        )
+        val authToken = userAuthFacade.register(registerUserCommand)
+
+        val user = userService.getById(userId)
+        val response = AuthResponse.of(user, authToken)
+
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/api/user/request/EventListQueryType.kt
+++ b/src/main/kotlin/api/user/request/EventListQueryType.kt
@@ -1,4 +1,4 @@
-package uket.api.user
+package uket.api.user.request
 
 enum class EventListQueryType {
     ALL,

--- a/src/main/kotlin/api/user/request/UserRegisterRequest.kt
+++ b/src/main/kotlin/api/user/request/UserRegisterRequest.kt
@@ -1,0 +1,6 @@
+package uket.api.user.request
+
+data class UserRegisterRequest(
+    val depositorName: String,
+    val phoneNumber: String,
+)

--- a/src/main/kotlin/auth/config/AuthConfig.kt
+++ b/src/main/kotlin/auth/config/AuthConfig.kt
@@ -26,6 +26,7 @@ class AuthConfig(
             .excludePathPatterns("/admin/users/login")
             .excludePathPatterns("/auth/**")
             .excludePathPatterns("/uket-events/**")
+            .excludePathPatterns("/users/register")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {

--- a/src/main/kotlin/auth/config/AuthConfig.kt
+++ b/src/main/kotlin/auth/config/AuthConfig.kt
@@ -6,12 +6,14 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uket.auth.config.adminId.LoginAdminIdArgumentResolver
+import uket.auth.config.adminId.LoginUserIdArgumentResolver
 import uket.auth.interceptor.LoginInterceptor
 
 @Configuration
 class AuthConfig(
     private val loginInterceptor: LoginInterceptor,
     private val loginAdminIdArgumentResolver: LoginAdminIdArgumentResolver,
+    private val loginUserIdArgumentResolver: LoginUserIdArgumentResolver,
 ) : WebMvcConfigurer {
     override fun addInterceptors(registry: InterceptorRegistry) {
         registry
@@ -35,6 +37,7 @@ class AuthConfig(
 
     override fun addArgumentResolvers(resolvers: MutableList<HandlerMethodArgumentResolver?>) {
         resolvers.add(loginAdminIdArgumentResolver)
+        resolvers.add(loginUserIdArgumentResolver)
         super.addArgumentResolvers(resolvers)
     }
 }

--- a/src/main/kotlin/auth/config/userId/LoginUserId.kt
+++ b/src/main/kotlin/auth/config/userId/LoginUserId.kt
@@ -1,0 +1,5 @@
+package uket.auth.config.adminId
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LoginUserId

--- a/src/main/kotlin/auth/config/userId/LoginUserIdArgumentResolver.kt
+++ b/src/main/kotlin/auth/config/userId/LoginUserIdArgumentResolver.kt
@@ -1,0 +1,24 @@
+package uket.auth.config.adminId
+
+import org.springframework.core.MethodParameter
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.bind.support.WebDataBinderFactory
+import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.method.support.ModelAndViewContainer
+
+@Component
+class LoginUserIdArgumentResolver : HandlerMethodArgumentResolver {
+    override fun supportsParameter(parameter: MethodParameter): Boolean = parameter.hasParameterAnnotation(LoginUserId::class.java)
+
+    override fun resolveArgument(
+        parameter: MethodParameter,
+        mavContainer: ModelAndViewContainer?,
+        webRequest: NativeWebRequest,
+        binderFactory: WebDataBinderFactory?,
+    ): Long {
+        val userId = SecurityContextHolder.getContext().authentication.name
+        return userId.toLong()
+    }
+}

--- a/src/main/kotlin/auth/config/userId/LoginUserIdArgumentResolver.kt
+++ b/src/main/kotlin/auth/config/userId/LoginUserIdArgumentResolver.kt
@@ -18,6 +18,12 @@ class LoginUserIdArgumentResolver : HandlerMethodArgumentResolver {
         webRequest: NativeWebRequest,
         binderFactory: WebDataBinderFactory?,
     ): Long {
+        val isUser = SecurityContextHolder
+            .getContext()
+            .authentication.authorities
+            .any { it.authority == "USERS" }
+        check(isUser) { "잘못된 토큰 전달입니다." }
+
         val userId = SecurityContextHolder.getContext().authentication.name
         return userId.toLong()
     }

--- a/src/main/kotlin/domain/uketevent/service/UketEventService.kt
+++ b/src/main/kotlin/domain/uketevent/service/UketEventService.kt
@@ -3,7 +3,7 @@ package uket.domain.uketevent.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uket.api.user.EventListQueryType
+import uket.api.user.request.EventListQueryType
 import uket.common.LoggerDelegate
 import uket.common.enums.EventType
 import uket.domain.uketevent.dto.EventListItem

--- a/src/main/kotlin/domain/user/service/UserService.kt
+++ b/src/main/kotlin/domain/user/service/UserService.kt
@@ -51,7 +51,7 @@ class UserService(
     /*
         유저 정보 등록
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRED)
     fun registerUser(registerUserCommand: RegisterUserCommand) {
         val user = this.getById(registerUserCommand.userId)
         user.register(registerUserCommand.depositorName, registerUserCommand.phoneNumber)

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import uket.api.user.EventListQueryType
+import uket.api.user.request.EventListQueryType
 import uket.domain.uketevent.entity.UketEvent
 import uket.domain.uketevent.repository.UketEventRepository
 import uket.domain.uketevent.service.UketEventService


### PR DESCRIPTION
# 📌 개요
- 일반 유저의 "입금자명", "전화번호" 정보를 등록하는 회원가입 API를 migration 했습니다.

# 💻 작업사항
- [x] LoginUserId 어노테이션과 resolver 추가
- [x] AuthController -> UserController로 변경

<details>
<summary>포스트맨 테스트</summary>
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/1f053156-1dab-4585-a4c1-45af2e486977" />
<img width="968" alt="image" src="https://github.com/user-attachments/assets/984de706-91a6-4bf0-84bd-1340c3940b09" />

</details>

# ❌ 주의사항
- 쿼리는 총 3개 발생합니다
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/1f6cfa2e-e42e-4d8e-a101-98720185bc46" />


# 💡 코드 리뷰 요청사항
- 