### PR TITLE
[UKET-100] 어드민 티켓 관련 코드 Migration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,9 @@ dependencies {
     // qrcode
     implementation("com.google.zxing:core:3.4.1")
     implementation("com.google.zxing:javase:3.4.1")
+
+    //ratelimit
+    implementation ("com.bucket4j:bucket4j-core:8.3.0")
 }
 
 tasks.test {

--- a/src/main/kotlin/api/admin/AdminTicketController.kt
+++ b/src/main/kotlin/api/admin/AdminTicketController.kt
@@ -3,14 +3,27 @@ package uket.api.admin
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
 import uket.api.admin.response.EnterUketEventResponse
+import uket.api.admin.response.LiveEnterUserResponse
+import uket.api.admin.response.TicketSearchResponse
 import uket.api.admin.response.UpdateTicketStatusResponse
+import uket.common.PublicException
+import uket.common.aop.ratelimit.LimitRequest
+import uket.common.response.CustomPageResponse
+import uket.domain.reservation.dto.TicketSearchDto
 import uket.domain.reservation.entity.Ticket
 import uket.domain.reservation.enums.TicketStatus
 import uket.domain.reservation.service.TicketService
+import uket.domain.reservation.service.search.TicketSearcher
 import uket.facade.EnterUketEventFacade
+import java.util.*
 
 @Tag(name = "어드민 티켓 관련 API", description = "어드민 티켓 관련 API 입니다.")
 @RestController
@@ -18,6 +31,7 @@ import uket.facade.EnterUketEventFacade
 class AdminTicketController(
     private val enterUketEventFacade: EnterUketEventFacade,
     private val ticketService: TicketService,
+    private val ticketSearchers: List<TicketSearcher>,
 
 ) {
     @Operation(summary = "입장 확인 API", description = "QR code를 통한 Token값으로 입장 확인을 할 수 있습니다.")
@@ -37,6 +51,53 @@ class AdminTicketController(
     ): ResponseEntity<UpdateTicketStatusResponse> {
         val ticket: Ticket = ticketService.updateTicketStatus(ticketId, ticketStatus)
         val response = UpdateTicketStatusResponse.from(ticket)
+        return ResponseEntity.ok(response)
+    }
+
+    @LimitRequest
+    @Operation(summary = "실시간 입장 내역 조회 API", description = "실시간 입장내역 조회를 합니다. 페이지는 1Page부터 시작합니다.")
+    @GetMapping("/live/enter-users/{uketEventId}")
+    fun searchLiveEnterUsers(
+        @RequestParam(defaultValue = "1") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+        @PathVariable("uketEventId") uketEventId: Long,
+    ): ResponseEntity<CustomPageResponse<LiveEnterUserResponse>> {
+        val response = enterUketEventFacade.searchLiveEnterUsers(
+            uketEventId,
+            PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "modifiedAt"))
+        )
+        return ResponseEntity.ok(CustomPageResponse(response))
+    }
+
+    @Operation(summary = "티켓 검색 API", description = "다양한 기준으로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
+    @GetMapping("/search/{uketEventId}")
+    fun searchTickets(
+        @RequestParam searchType: TicketSearchType,
+        @ModelAttribute searchRequest: SearchRequest,
+        @RequestParam(defaultValue = "1") page: Int,
+        @RequestParam(defaultValue = "10") size: Int,
+        @PathVariable("uketEventId") uketEventId: Long,
+    ): ResponseEntity<CustomPageResponse<TicketSearchResponse>> {
+        val pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "modifiedAt"))
+        val ticketSearchType = searchType ?: TicketSearchType.DEFAULT
+
+        val tickets: Page<TicketSearchDto> =
+            if (ticketSearchType == TicketSearchType.NONE) {
+                ticketService.searchAllTickets(uketEventId, pageRequest)
+            } else {
+                ticketSearchers.stream()
+                    .filter { it.isSupport(ticketSearchType) }
+                    .findFirst().orElseThrow{
+                        throw PublicException(
+                            publicMessage = "잘못된 검색 타입입니다.",
+                            systemMessage = "Not Valid TicketSearchType : TICKETSEARCHTYPE =$ticketSearchType",
+                            title = "잘못된 검색 타입"
+                        )
+                    }
+                    .search(uketEventId,searchRequest,pageRequest);
+            }
+
+        val response = CustomPageResponse(TicketSearchResponse.from(tickets))
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/api/admin/AdminTicketController.kt
+++ b/src/main/kotlin/api/admin/AdminTicketController.kt
@@ -4,17 +4,20 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import uket.api.admin.response.EnterUketEventResponse
+import uket.api.admin.response.UpdateTicketStatusResponse
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.enums.TicketStatus
+import uket.domain.reservation.service.TicketService
 import uket.facade.EnterUketEventFacade
 
 @Tag(name = "어드민 티켓 관련 API", description = "어드민 티켓 관련 API 입니다.")
 @RestController
 @ApiResponse(responseCode = "200", description = "단체")
-class TicketController(
+class AdminTicketController(
     private val enterUketEventFacade: EnterUketEventFacade,
+    private val ticketService: TicketService,
 
 ) {
     @Operation(summary = "입장 확인 API", description = "QR code를 통한 Token값으로 입장 확인을 할 수 있습니다.")
@@ -23,6 +26,17 @@ class TicketController(
         @PathVariable("token") ticketToken: String
     ): ResponseEntity<EnterUketEventResponse> {
         val response: EnterUketEventResponse = enterUketEventFacade.enterUketEvent(ticketToken)
+        return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "티켓 상태 변경 API", description = "어드민용 티켓 상태를 변경합니다.")
+    @PatchMapping("/{ticketId}/status/{ticketStatus}")
+    fun updateTicketStatus(
+        @PathVariable("ticketId") ticketId: Long,
+        @PathVariable("ticketStatus") ticketStatus: TicketStatus,
+    ): ResponseEntity<UpdateTicketStatusResponse> {
+        val ticket: Ticket = ticketService.updateTicketStatus(ticketId, ticketStatus)
+        val response = UpdateTicketStatusResponse.from(ticket)
         return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/api/admin/TicketController.kt
+++ b/src/main/kotlin/api/admin/TicketController.kt
@@ -1,0 +1,28 @@
+package uket.api.admin
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+import uket.api.admin.response.EnterUketEventResponse
+import uket.facade.EnterUketEventFacade
+
+@Tag(name = "어드민 티켓 관련 API", description = "어드민 티켓 관련 API 입니다.")
+@RestController
+@ApiResponse(responseCode = "200", description = "단체")
+class TicketController(
+    private val enterUketEventFacade: EnterUketEventFacade,
+
+) {
+    @Operation(summary = "입장 확인 API", description = "QR code를 통한 Token값으로 입장 확인을 할 수 있습니다.")
+    @PostMapping("/{token}/enter")
+    fun enterShow(
+        @PathVariable("token") ticketToken: String
+    ): ResponseEntity<EnterUketEventResponse> {
+        val response: EnterUketEventResponse = enterUketEventFacade.enterUketEvent(ticketToken)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/api/admin/dto/LiveEnterUserDto.kt
+++ b/src/main/kotlin/api/admin/dto/LiveEnterUserDto.kt
@@ -1,0 +1,12 @@
+package uket.api.admin.dto
+
+import uket.domain.reservation.enums.TicketStatus
+import java.time.LocalDateTime
+
+data class LiveEnterUserDto(
+    val enterTime: LocalDateTime,
+    val name: String,
+    val ticketDate: LocalDateTime,
+    val phoneNumber: String,
+    val ticketStatus: TicketStatus,
+)

--- a/src/main/kotlin/api/admin/enums/TicketSearchType.kt
+++ b/src/main/kotlin/api/admin/enums/TicketSearchType.kt
@@ -1,0 +1,18 @@
+package uket.api.admin.enums
+
+enum class TicketSearchType {
+    STATUS,
+    USER_NAME,
+    PHONE_NUMBER,
+    SHOW_DATE,
+    RESERVATION_USER_TYPE,
+    CREATED_AT,
+    MODIFIED_AT,
+    NONE;
+
+    companion object {
+        val DEFAULT = NONE
+
+        fun from()
+    }
+}

--- a/src/main/kotlin/api/admin/request/SearchRequest.kt
+++ b/src/main/kotlin/api/admin/request/SearchRequest.kt
@@ -1,0 +1,18 @@
+package uket.api.admin.request
+
+import org.springframework.format.annotation.DateTimeFormat
+import uket.domain.reservation.enums.TicketStatus
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+data class SearchRequest(
+    val status: TicketStatus? = null,
+    val userName: String? = null,
+    val phoneNumberLastFourDigits: String? = null,
+    @DateTimeFormat(pattern = "yy.MM.dd")
+    val showDate: LocalDate? = null,
+    @DateTimeFormat(pattern = "yy.MM.dd HH:mm")
+    val createdAt: LocalDateTime? = null,
+    @DateTimeFormat(pattern = "yy.MM.dd HH:mm")
+    val modifiedAt: LocalDateTime? = null
+)

--- a/src/main/kotlin/api/admin/response/EnterUketEventResponse.kt
+++ b/src/main/kotlin/api/admin/response/EnterUketEventResponse.kt
@@ -1,0 +1,25 @@
+package uket.api.admin.response
+
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.enums.TicketStatus
+import uket.domain.user.entity.User
+
+data class EnterUketEventResponse(
+    val ticketId: Long,
+    val userId: Long,
+    val userName: String,
+    val status: TicketStatus,
+    val msg: String,
+) {
+    companion object {
+        fun of(ticket: Ticket, user: User): EnterUketEventResponse {
+            return EnterUketEventResponse(
+                ticketId = ticket.id,
+                userId =  ticket.userId,
+                userName = user.name,
+                status = ticket.status,
+                msg = ticket.status.msg,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/api/admin/response/LiveEnterUserResponse.kt
+++ b/src/main/kotlin/api/admin/response/LiveEnterUserResponse.kt
@@ -1,0 +1,32 @@
+package uket.api.admin.response
+
+import uket.api.admin.dto.LiveEnterUserDto
+import uket.common.aop.masking.Mask
+import uket.common.aop.masking.MaskingType
+import uket.domain.reservation.enums.TicketStatus
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class LiveEnterUserResponse(
+    val enterTime: ZonedDateTime,
+    val name: String,
+    val ticketDate: ZonedDateTime,
+    @Mask(type = MaskingType.PHONE)
+    val phoneNumber: String,
+    val ticketStatus: TicketStatus,
+) {
+    companion object {
+        private val zoneId = ZoneId.of("Asia/Seoul")
+
+        fun from(dto: LiveEnterUserDto): LiveEnterUserResponse {
+            return LiveEnterUserResponse(
+                enterTime = dto.enterTime.atZone(zoneId),
+                name = dto.name,
+                ticketDate = dto.ticketDate.atZone(zoneId),
+                phoneNumber = dto.phoneNumber,
+                ticketStatus = dto.ticketStatus
+            )
+        }
+    }
+}
+

--- a/src/main/kotlin/api/admin/response/TicketSearchResponse.kt
+++ b/src/main/kotlin/api/admin/response/TicketSearchResponse.kt
@@ -1,0 +1,41 @@
+package uket.api.admin.response
+
+import org.springframework.data.domain.Page
+import uket.common.aop.masking.Mask
+import uket.common.aop.masking.MaskingType
+import uket.domain.reservation.dto.TicketSearchDto
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+data class TicketSearchResponse(
+    val ticketId: Long,
+    val depositorName: String,
+    @Mask(type = MaskingType.PHONE)
+    val telephone: String,
+    val showTime: ZonedDateTime,
+    val orderDate: ZonedDateTime,
+    val updatedDate: ZonedDateTime,
+    val ticketStatus: String,
+    val friend: String,
+) {
+    companion object {
+        private val zoneId = ZoneId.of("Asia/Seoul")
+
+        fun from(ticket: TicketSearchDto): TicketSearchResponse {
+            return TicketSearchResponse(
+                ticketId = ticket.ticketId,
+                depositorName = ticket.depositorName,
+                telephone = ticket.telephone,
+                showTime = ticket.showTime.atZone(zoneId),
+                orderDate = ticket.orderDate.atZone(zoneId),
+                updatedDate = ticket.updatedDate.atZone(zoneId),
+                ticketStatus = ticket.ticketStatus.value,
+                friend = ticket.friend
+            )
+        }
+
+        fun from(tickets: Page<TicketSearchDto>): Page<TicketSearchResponse> {
+            return tickets.map { from(it) }
+        }
+    }
+}

--- a/src/main/kotlin/api/admin/response/UpdateTicketStatusResponse.kt
+++ b/src/main/kotlin/api/admin/response/UpdateTicketStatusResponse.kt
@@ -1,0 +1,18 @@
+package uket.api.admin.response
+
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.enums.TicketStatus
+
+data class UpdateTicketStatusResponse(
+    val ticketId: Long,
+    val status: TicketStatus,
+) {
+    companion object {
+        fun from(ticket: Ticket): UpdateTicketStatusResponse {
+            return UpdateTicketStatusResponse(
+                ticketId = ticket.id,
+                status = ticket.status,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/auth/jwt/JwtTicketUtil.kt
+++ b/src/main/kotlin/auth/jwt/JwtTicketUtil.kt
@@ -1,0 +1,35 @@
+package uket.auth.jwt
+
+import io.jsonwebtoken.Jwts
+import uket.auth.jwt.JwtValues.JWT_PAYLOAD_KEY_CATEGORY
+import uket.auth.jwt.JwtValues.JWT_PAYLOAD_KEY_ID
+import uket.auth.jwt.JwtValues.JWT_PAYLOAD_VALUE_TICKET
+import java.util.*
+import javax.crypto.SecretKey
+
+class JwtTicketUtil(
+    private val tokenProperties: TokenProperties,
+    private val secretKey: SecretKey,
+) {
+
+    fun getTicketId(token: String?): Long {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).payload
+            .get(JwtValues.JWT_PAYLOAD_KEY_ID, Long::class.java)
+    }
+
+    fun createTicketToken(ticketId: Long?): String {
+        val now = System.currentTimeMillis()
+
+        return Jwts.builder()
+            .claim(JWT_PAYLOAD_KEY_CATEGORY, JWT_PAYLOAD_VALUE_TICKET)
+            .claim(JWT_PAYLOAD_KEY_ID, ticketId)
+            .issuedAt(Date(now))
+            .expiration(getTicketInfoExpiration(now))
+            .signWith(secretKey)
+            .compact()
+    }
+
+    private fun getTicketInfoExpiration(now: Long): Date {
+        return Date(now + tokenProperties.expiration.ticketTokenExpiration)
+    }
+}

--- a/src/main/kotlin/auth/jwt/JwtValues.kt
+++ b/src/main/kotlin/auth/jwt/JwtValues.kt
@@ -12,4 +12,5 @@ object JwtValues {
     const val JWT_AUTHORIZATION_VALUE_PREFIX: String = "Bearer "
     const val JWT_PAYLOAD_VALUE_ACCESS: String = "access"
     const val JWT_PAYLOAD_VALUE_REFRESH: String = "refresh"
+    const val JWT_PAYLOAD_VALUE_TICKET: String = "ticket"
 }

--- a/src/main/kotlin/auth/jwt/TokenProperties.kt
+++ b/src/main/kotlin/auth/jwt/TokenProperties.kt
@@ -16,5 +16,6 @@ data class TokenProperties(
         val accessTokenExpiration: Long,
         val refreshTokenExpiration: Long,
         val emailTokenExpiration: Long,
+        val ticketTokenExpiration: Long,
     )
 }

--- a/src/main/kotlin/common/aop/masking/Mask.kt
+++ b/src/main/kotlin/common/aop/masking/Mask.kt
@@ -1,0 +1,6 @@
+package uket.common.aop.masking
+
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Mask(val type: MaskingType)

--- a/src/main/kotlin/common/aop/masking/MaskingAspect.kt
+++ b/src/main/kotlin/common/aop/masking/MaskingAspect.kt
@@ -1,0 +1,46 @@
+package uket.common.aop.masking
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+import uket.common.response.CustomPageResponse
+
+@Aspect
+@Component
+class MaskingAspect {
+
+    @Around("execution(* uket.api.*Controller.*(..))")
+    fun maskReturnValue(joinPoint: ProceedingJoinPoint): Any? {
+        val result = joinPoint.proceed()
+        return when (result) {
+            is CustomPageResponse<*> -> {
+                val maskedContent = result.content.mapNotNull { maskDtoIfNeeded(it) }
+                CustomPageResponse(
+                    content = maskedContent,
+                    pageNumber = result.pageNumber,
+                    pageSize = result.pageSize,
+                    first = result.first,
+                    last = result.last,
+                    totalElements = result.totalElements,
+                    totalPages = result.totalPages,
+                    empty = result.empty
+                )
+            }
+            else -> maskDtoIfNeeded(result)
+        }
+    }
+
+    private fun maskDtoIfNeeded(dto: Any?): Any? {
+        if (dto == null) return null
+        val dtoClass = dto::class
+        if (!dtoClass.isData) return dto
+
+        return try {
+            MaskingProcessor.applyMasking(dto)
+        } catch (e: Exception) {
+            dto
+        }
+    }
+}
+

--- a/src/main/kotlin/common/aop/masking/MaskingProcessor.kt
+++ b/src/main/kotlin/common/aop/masking/MaskingProcessor.kt
@@ -1,0 +1,23 @@
+package uket.common.aop.masking
+
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+
+object MaskingProcessor {
+    fun <T : Any> applyMasking(dto: T): T {
+        val dtoClass = dto::class
+        val constructor = dtoClass.primaryConstructor ?: return dto
+
+        val args = constructor.parameters.map { parameter ->
+            val property = dtoClass.memberProperties.find { it.name == parameter.name } ?: return@map null
+            val originalValue = property.getter.call(dto)
+            val maskedValue = property.findAnnotation<Mask>()?.let {
+                if (originalValue is String) MaskingUtil.maskingOf(it.type, originalValue) else originalValue
+            } ?: originalValue
+            maskedValue
+        }.toTypedArray()
+
+        return constructor.call(*args)
+    }
+}

--- a/src/main/kotlin/common/aop/masking/MaskingType.kt
+++ b/src/main/kotlin/common/aop/masking/MaskingType.kt
@@ -1,0 +1,6 @@
+package uket.common.aop.masking
+
+enum class MaskingType {
+    NAME,
+    PHONE
+}

--- a/src/main/kotlin/common/aop/masking/MaskingUtil.kt
+++ b/src/main/kotlin/common/aop/masking/MaskingUtil.kt
@@ -1,0 +1,31 @@
+package uket.common.aop.masking
+
+object MaskingUtil {
+
+    fun maskingOf(type: MaskingType, value: String?): String {
+        if (value.isNullOrBlank()) return value ?: ""
+        return when (type) {
+            MaskingType.NAME -> nameMaskOf(value)
+            MaskingType.PHONE -> phoneNumberMaskOf(value)
+        }
+    }
+
+    private fun nameMaskOf(value: String): String {
+        // 홍*동 마스킹: 첫글자, 마지막글자 제외 마스킹
+        return if (value.length <= 2) {
+            value.first() + "*"
+        } else {
+            val maskedMiddle = "*".repeat(value.length - 2)
+            value.first() + maskedMiddle + value.last()
+        }
+    }
+
+    private fun phoneNumberMaskOf(value: String): String {
+        val cleaned = value.replace("-", "")
+        val regex = Regex("(\\d{3})(\\d{4})(\\d{4})")
+        return regex.replace(cleaned) { matchResult ->
+            val (part1, _, part3) = matchResult.destructured
+            "$part1****$part3"
+        }
+    }
+}

--- a/src/main/kotlin/common/aop/ratelimit/LimitRequest.kt
+++ b/src/main/kotlin/common/aop/ratelimit/LimitRequest.kt
@@ -1,0 +1,5 @@
+package uket.common.aop.ratelimit
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class LimitRequest

--- a/src/main/kotlin/common/aop/ratelimit/LimitRequestAspect.kt
+++ b/src/main/kotlin/common/aop/ratelimit/LimitRequestAspect.kt
@@ -1,0 +1,26 @@
+package uket.common.aop.ratelimit
+
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.springframework.stereotype.Component
+import uket.common.PublicException
+import java.time.Duration
+
+@Aspect
+@Component
+class LimitRequestAspect() {
+    private val bucket: Bucket = Bucket.builder()
+        .addLimit(Bandwidth.simple(100, Duration.ofMinutes(1)))
+        .build()
+
+    @Before("@annotation(uket.common.aop.ratelimit.LimitRequest)")
+    fun limitRequest() {
+        if (!bucket.tryConsume(1)) {
+            throw PublicException()
+        }
+    }
+
+
+}

--- a/src/main/kotlin/domain/reservation/dto/TicketSearchDto.kt
+++ b/src/main/kotlin/domain/reservation/dto/TicketSearchDto.kt
@@ -1,0 +1,33 @@
+package uket.domain.reservation.dto
+
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.enums.TicketStatus
+import uket.domain.uketevent.entity.UketEventRound
+import uket.domain.user.entity.User
+import java.time.LocalDateTime
+
+data class TicketSearchDto(
+    val ticketId: Long,
+    val depositorName: String,
+    val telephone: String,
+    val showTime: LocalDateTime,
+    val orderDate: LocalDateTime,
+    val updatedDate: LocalDateTime,
+    val ticketStatus: TicketStatus,
+    val friend: String,
+) {
+    companion object {
+        fun from(ticket: Ticket, user: User, uketEventRound: UketEventRound): TicketSearchDto {
+            return TicketSearchDto(
+                ticketId = ticket.id,
+                depositorName = user.depositorName!!,
+                telephone = user.phoneNumber!!,
+                showTime = uketEventRound.eventRoundDateTime,
+                orderDate = ticket.createdAt,
+                updatedDate = ticket.updatedAt,
+                ticketStatus = ticket.status,
+                friend = ""
+            )
+        }
+    }
+}

--- a/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
+++ b/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
@@ -4,18 +4,143 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import uket.api.admin.dto.LiveEnterUserDto
+import uket.domain.reservation.dto.TicketSearchDto
 import uket.domain.reservation.entity.Ticket
 import uket.domain.reservation.enums.TicketStatus
 import java.time.LocalDateTime
 
 interface TicketRepository : JpaRepository<Ticket, Long> {
-    fun findByStatus(status: TicketStatus, pageable: Pageable): Page<Ticket>
+    @Query("""
+    SELECT new uket.domain.reservation.dto.TicketSearchDto(
+        t.id,
+        u.depositorName,
+        u.phoneNumber,
+        ur.eventRoundDateTime,
+        t.createdAt,
+        t.updatedAt,
+        t.status,
+        ''
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId
+      AND t.status = :status
+""")
+    fun findByStatus(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("status") status: TicketStatus,
+        pageable: Pageable
+    ): Page<TicketSearchDto>
 
-    fun findByCreatedAtBetween(startAt: LocalDateTime, endAt: LocalDateTime, pageable: Pageable): Page<Ticket>
+    @Query("""
+    SELECT new uket.domain.reservation.dto.TicketSearchDto(
+        t.id,
+        u.depositorName,
+        u.phoneNumber,
+        ur.eventRoundDateTime,
+        t.createdAt,
+        t.updatedAt,
+        t.status,
+        ''
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId
+      AND t.createdAt BETWEEN :startAt AND :endAt
+""")
+    fun findByCreatedAtBetween(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("startAt") startAt: LocalDateTime,
+        @Param("endAt") endAt: LocalDateTime,
+        pageable: Pageable
+    ): Page<TicketSearchDto>
 
-    fun findByUpdatedAtBetween(startAt: LocalDateTime, endAt: LocalDateTime, pageable: Pageable): Page<Ticket>
+    @Query("""
+    SELECT new uket.domain.reservation.dto.TicketSearchDto(
+        t.id,
+        u.depositorName,
+        u.phoneNumber,
+        ur.eventRoundDateTime,
+        t.createdAt,
+        t.updatedAt,
+        t.status,
+        ''
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId
+      AND t.createdAt BETWEEN :startAt AND :endAt
+""")
+    fun findByUpdatedAtBetween(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("startAt") startAt: LocalDateTime,
+        @Param("endAt") endAt: LocalDateTime,
+        pageable: Pageable
+    ): Page<TicketSearchDto>
 
     fun findByUserIdAndId(userId: Long, ticketId: Long): Ticket?
+
+    @Query("""
+    SELECT new uket.domain.reservation.dto.TicketSearchDto(
+        t.id,
+        u.depositorName,
+        u.phoneNumber,
+        ur.eventRoundDateTime,
+        t.createdAt,
+        t.updatedAt,
+        t.status,
+        ''
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId
+      AND u.name = :userName
+""")
+    fun findByUserName(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("userName") userName: String,
+        pageable: Pageable
+    ): Page<TicketSearchDto>
+
+    @Query("""
+    SELECT new uket.domain.reservation.dto.TicketSearchDto(
+        t.id,
+        u.depositorName,
+        u.phoneNumber,
+        ur.eventRoundDateTime,
+        t.createdAt,
+        t.updatedAt,
+        t.status,
+        ''
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId
+      AND ur.eventRoundDateTime BETWEEN :startAt AND :endAt
+""")
+    fun findByEventRoundTime(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("startAt") startAt: LocalDateTime,
+        @Param("endAt") endAt: LocalDateTime,
+        pageable: Pageable
+    ): Page<TicketSearchDto>
 
     @Query(
         """
@@ -45,6 +170,65 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
         nativeQuery = true,
     )
     fun findAllByUserIdAndStatusNotWithEntryGroup(userId: Long, status: TicketStatus): List<Ticket>
+
+    @Query("""
+    SELECT new uket.api.admin.dto.LiveEnterUserDto(
+        t.enterAt,
+        u.depositorName,
+        ur.eventRoundDateTime,
+        u.phoneNumber,
+        t.status
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId AND t.status = :status
+""")
+    fun findLiveEnterUserDtosByUketEventAndRoundId(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("status") status: TicketStatus,
+        pageable: Pageable
+    ): Page<LiveEnterUserDto>
+
+    @Query("""
+    SELECT t
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    WHERE e.id = :uketEventId
+""")
+    fun findAllByEventId(
+        @Param("uketEventId") uketEventId: Long,
+        pageable: Pageable
+    ) : Page<Ticket>
+
+    @Query("""
+    SELECT new uket.domain.reservation.dto.TicketSearchDto(
+        t.id,
+        u.depositorName,
+        u.phoneNumber,
+        ur.eventRoundDateTime,
+        t.createdAt,
+        t.updatedAt,
+        t.status,
+        ''
+    )
+    FROM Ticket t
+    JOIN EntryGroup eg ON eg.id = t.entryGroupId
+    JOIN eg.uketEventRound ur
+    JOIN ur.uketEvent e
+    JOIN User u ON u.id = t.userId
+    WHERE e.id = :uketEventId
+      AND u.phoneNumber LIKE %:lastFourDigits
+""")
+    fun findByPhoneNumberEndingWith(
+        @Param("uketEventId") uketEventId: Long,
+        @Param("lastFourDigits") lastFourDigits: String,
+        pageable: Pageable
+    ): Page<TicketSearchDto>
 
     fun existsByUserIdAndId(userId: Long, ticketId: Long): Boolean
 

--- a/src/main/kotlin/domain/reservation/service/TicketService.kt
+++ b/src/main/kotlin/domain/reservation/service/TicketService.kt
@@ -56,6 +56,13 @@ class TicketService(
     }
 
     @Transactional
+    fun updateTicketStatus(ticketId: Long, ticketStatus: TicketStatus): Ticket {
+        val ticket: Ticket = ticketRepository.findById(ticketId).get()
+        ticket.updateStatus(ticketStatus)
+        return ticketRepository.save(ticket)
+    }
+
+    @Transactional
     fun cancelTicketByUserIdAndId(userId: Long, ticketId: Long) {
         val ticket: Ticket = ticketRepository.findByUserIdAndId(userId, ticketId)
             ?: throw IllegalStateException("해당 티켓을 찾을 수 없습니다.")

--- a/src/main/kotlin/domain/reservation/service/TicketService.kt
+++ b/src/main/kotlin/domain/reservation/service/TicketService.kt
@@ -5,7 +5,9 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.dto.LiveEnterUserDto
 import uket.domain.reservation.dto.CreateTicketCommand
+import uket.domain.reservation.dto.TicketSearchDto
 import uket.domain.reservation.entity.Ticket
 import uket.domain.reservation.enums.TicketStatus
 import uket.domain.reservation.repository.TicketRepository
@@ -32,9 +34,13 @@ class TicketService(
         return ticketRepository.findValidTicketsByUserIdAndStatusNotIn(userId, excludedStatuses)
     }
 
-    fun searchAllTickets(pageable: Pageable): Page<Ticket> {
-        val tickets = ticketRepository.findAll(pageable)
-        return tickets
+    fun findLiveEnterTickets(eventId: Long, pageable: Pageable): Page<LiveEnterUserDto> {
+        return ticketRepository.findLiveEnterUserDtosByUketEventAndRoundId(eventId, TicketStatus.FINISH_ENTER, pageable)
+    }
+
+    fun searchAllTickets(eventId: Long, pageable: Pageable): Page<TicketSearchDto> {
+        val tickets = ticketRepository.findAllByEventId(eventId, pageable)
+        return tickets.map(TicketSearchDto::from)
     }
 
     @Transactional

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcher.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcher.kt
@@ -1,0 +1,18 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.repository.TicketRepository
+
+interface SearchTicket {
+    fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto>
+}
+
+abstract class TicketSearcher(
+    protected val ticketRepository: TicketRepository
+) : SearchTicket {
+    abstract fun isSupport(searchType: TicketSearchType): Boolean
+}

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByCreatedAt.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByCreatedAt.kt
@@ -1,0 +1,35 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.dto.TicketSearchDto.Companion.from
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.repository.TicketRepository
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Service
+class TicketSearcherByCreatedAt(
+    ticketRepository: TicketRepository
+) : TicketSearcher(ticketRepository) {
+
+    override fun isSupport(searchType: TicketSearchType): Boolean {
+        return searchType == TicketSearchType.CREATED_AT
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(uketEventId:Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+        val createdAt = searchRequest.createdAt
+            ?: throw IllegalStateException("createdAt은 null일 수 없습니다.")
+
+        val createStart = createdAt.toLocalDate().atTime(LocalTime.MIN)
+        val createEnd = createdAt.toLocalDate().atTime(LocalTime.MAX)
+
+        return ticketRepository.findByCreatedAtBetween(uketEventId,createStart, createEnd, pageable)
+    }
+}

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByEventRoundDateTime.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByEventRoundDateTime.kt
@@ -1,0 +1,34 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.repository.TicketRepository
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+@Service
+class TicketSearcherByEventRoundDateTime(
+    ticketRepository: TicketRepository
+) : TicketSearcher(ticketRepository) {
+
+    override fun isSupport(searchType: TicketSearchType): Boolean {
+        return searchType == TicketSearchType.SHOW_DATE
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+        val showDate = searchRequest.showDate
+            ?: throw IllegalStateException("showDate가 null일 수 없습니다.")
+
+        val showStart: LocalDateTime = showDate.atStartOfDay()
+        val showEnd: LocalDateTime = showDate.atTime(LocalTime.MAX)
+
+        return ticketRepository.findByEventRoundTime(uketEventId, showStart,showEnd,pageable);
+    }
+}

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByModifiedAt.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByModifiedAt.kt
@@ -1,0 +1,33 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.repository.TicketRepository
+import java.time.LocalTime
+
+@Service
+class TicketSearcherByModifiedAt(
+    ticketRepository: TicketRepository
+) : TicketSearcher(ticketRepository) {
+
+    override fun isSupport(searchType: TicketSearchType): Boolean {
+        return searchType == TicketSearchType.MODIFIED_AT
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+        val modifiedAt = searchRequest.modifiedAt
+            ?: throw IllegalStateException("modifiedAt은 null일 수 없습니다.")
+
+        val modifyStart = modifiedAt.toLocalDate().atTime(LocalTime.MIN)
+        val modifyEnd = modifiedAt.toLocalDate().atTime(LocalTime.MAX)
+
+        return ticketRepository.findByUpdatedAtBetween(uketEventId, modifyStart, modifyEnd, pageable)
+    }
+}

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByPhoneNumber.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByPhoneNumber.kt
@@ -1,0 +1,26 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.repository.TicketRepository
+
+@Service
+class TicketSearcherByPhoneNumber(
+    ticketRepository: TicketRepository
+) : TicketSearcher(ticketRepository) {
+
+    override fun isSupport(searchType: TicketSearchType): Boolean {
+        return searchType == TicketSearchType.PHONE_NUMBER
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(uketEventId:Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+        return ticketRepository.findByPhoneNumberEndingWith(uketEventId, searchRequest.phoneNumberLastFourDigits!!, pageable)
+    }
+}

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByStatus.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByStatus.kt
@@ -1,0 +1,26 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.repository.TicketRepository
+
+@Service
+class TicketSearcherByStatus (
+    ticketRepository: TicketRepository
+) : TicketSearcher(ticketRepository) {
+
+    override fun isSupport(searchType: TicketSearchType): Boolean {
+        return searchType == TicketSearchType.STATUS
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(uketEventId:Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+        return ticketRepository.findByStatus(uketEventId, searchRequest.status!!, pageable)
+    }
+}

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByUserName.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByUserName.kt
@@ -1,0 +1,26 @@
+package uket.domain.reservation.service.search
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.enums.TicketSearchType
+import uket.api.admin.request.SearchRequest
+import uket.domain.reservation.dto.TicketSearchDto
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.repository.TicketRepository
+
+@Service
+class TicketSearcherByUserName(
+    ticketRepository: TicketRepository
+) : TicketSearcher(ticketRepository) {
+
+    override fun isSupport(searchType: TicketSearchType): Boolean {
+        return searchType == TicketSearchType.STATUS
+    }
+
+    @Transactional(readOnly = true)
+    override fun search(uketEventId:Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+        return ticketRepository.findByUserName(uketEventId, searchRequest.userName!!, pageable)
+    }
+}

--- a/src/main/kotlin/facade/EnterUketEventFacade.kt
+++ b/src/main/kotlin/facade/EnterUketEventFacade.kt
@@ -1,0 +1,60 @@
+package uket.facade
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.response.EnterUketEventResponse
+import uket.auth.filter.TokenValidator
+import uket.auth.jwt.JwtTicketUtil
+import uket.auth.jwt.JwtValues.JWT_PAYLOAD_VALUE_TICKET
+import uket.common.PublicException
+import uket.domain.reservation.entity.Ticket
+import uket.domain.reservation.enums.TicketStatus
+import uket.domain.reservation.service.TicketService
+import uket.domain.user.entity.User
+import uket.domain.user.service.UserService
+
+@Service
+class EnterUketEventFacade(
+    private val tokenValidator: TokenValidator,
+    private val jwtTicketUtil: JwtTicketUtil,
+    private val ticketService: TicketService,
+    private val userService: UserService,
+) {
+    @Transactional
+    fun enterUketEvent(ticketToken: String): EnterUketEventResponse {
+        tokenValidator.validateExpiredToken(ticketToken)
+        tokenValidator.validateTokenCategory(JWT_PAYLOAD_VALUE_TICKET, ticketToken)
+        tokenValidator.validateTokenSignature(ticketToken)
+
+        val ticketId = jwtTicketUtil.getTicketId(ticketToken)
+        val ticket: Ticket = ticketService.getById(ticketId)
+        val user: User = userService.getById(ticket.userId)
+
+        validateBeforePaymentTicket(ticket.status)
+        validateAlreadyEnterTicket(ticket.status)
+
+        ticket.enter()
+
+        return EnterUketEventResponse.of(ticket, user)
+    }
+
+    private fun validateBeforePaymentTicket(status: TicketStatus) {
+        if (status == TicketStatus.BEFORE_PAYMENT) {
+            throw PublicException(
+                publicMessage = "예약은 완료되었으나 아직 해당 티켓 금액이 입금되지 않았습니다.",
+                systemMessage = "Not Valid TicketStatus For Enter : TICKETSTATUS =$status",
+                title = "입금되지 않은 티켓"
+            )
+        }
+    }
+
+    private fun validateAlreadyEnterTicket(status: TicketStatus) {
+        if (status == TicketStatus.FINISH_ENTER) {
+            throw PublicException(
+                publicMessage = "입장이 이미 완료된 티켓입니다. 재입장은 담당자에게 문의 부탁드립니다.",
+                systemMessage = "Not Valid TicketStatus For Enter : TICKETSTATUS =$status",
+                title = "입장이 완료된 티켓"
+            )
+        }
+    }
+}

--- a/src/main/kotlin/facade/EnterUketEventFacade.kt
+++ b/src/main/kotlin/facade/EnterUketEventFacade.kt
@@ -1,8 +1,12 @@
 package uket.facade
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uket.api.admin.dto.LiveEnterUserDto
 import uket.api.admin.response.EnterUketEventResponse
+import uket.api.admin.response.LiveEnterUserResponse
 import uket.auth.filter.TokenValidator
 import uket.auth.jwt.JwtTicketUtil
 import uket.auth.jwt.JwtValues.JWT_PAYLOAD_VALUE_TICKET
@@ -36,6 +40,12 @@ class EnterUketEventFacade(
         ticket.enter()
 
         return EnterUketEventResponse.of(ticket, user)
+    }
+
+    @Transactional(readOnly = true)
+    fun searchLiveEnterUsers(uketEventId: Long, pageable: Pageable): Page<LiveEnterUserResponse> {
+        val liveEnterUserDto: Page<LiveEnterUserDto> = ticketService.findLiveEnterTickets(uketEventId, pageable)
+        return liveEnterUserDto.map {dto -> LiveEnterUserResponse.from(dto)}
     }
 
     private fun validateBeforePaymentTicket(status: TicketStatus) {

--- a/src/main/kotlin/facade/S3ImageFacade.kt
+++ b/src/main/kotlin/facade/S3ImageFacade.kt
@@ -1,6 +1,7 @@
 package uket.facade
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
 import uket.api.admin.response.EventImageUploadResponse
 import uket.domain.images.entity.Image
@@ -13,6 +14,7 @@ class S3ImageFacade(
     private val imageRepository: ImageRepository,
     private val s3Service: S3Service,
 ) {
+    @Transactional
     fun uploadUketEventImages(
         eventImage: MultipartFile?,
         thumbnailImage: MultipartFile?,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -57,6 +57,7 @@ app:
       access-token-expiration: 600_000
       refresh-token-expiration: 7_200_000
       email-token-expiration: 86_400_000
+      ticket-token-expiration: 1_200_000
   kakao:
     token_uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
# 📌 개요
- 어드민 관련 티켓 코드 Migration을 진행했습니다.

# 💻 작업사항
- [x] 기존 티켓 api 코드 Migration
- [x] 조회 시 해당 event의 행사만 조회할 수 있도록 eventId 추가

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 저희가 도메인 간 결합을 약하게 만들어 service에서 관련 객체들을 찾아서 진행하면 N+1문제가 발생할 거 같아 Repository에서 dto를 직접 만들어 반환하는 식으로 구현해두었습니다. 관련해서 피드백 해주시면 감사하겠습니다!