### PR TITLE
[UKET-106] 어드민 티켓 조회 시 필터 변수 추가

### DIFF
--- a/src/main/kotlin/api/admin/AdminTicketController.kt
+++ b/src/main/kotlin/api/admin/AdminTicketController.kt
@@ -79,6 +79,7 @@ class AdminTicketController(
     @Operation(summary = "티켓 검색 API", description = "다양한 기준으로 티켓을 페이지별로 조회합니다. 페이지는 1Page부터 시작합니다.")
     @GetMapping("/search/{uketEventId}")
     fun searchTickets(
+        @RequestParam(required = false) uketEventRoundId: Long?,
         @RequestParam searchType: TicketSearchType,
         @ModelAttribute searchRequest: SearchRequest,
         @RequestParam(defaultValue = "1") page: Int,
@@ -90,7 +91,7 @@ class AdminTicketController(
 
         val tickets: Page<TicketSearchDto> =
             if (ticketSearchType == TicketSearchType.NONE) {
-                ticketService.searchAllTickets(uketEventId, pageRequest)
+                ticketService.searchAllTickets(uketEventId, uketEventRoundId, pageRequest)
             } else {
                 ticketSearchers.stream()
                     .filter { it.isSupport(ticketSearchType) }
@@ -101,7 +102,7 @@ class AdminTicketController(
                             title = "잘못된 검색 타입"
                         )
                     }
-                    .search(uketEventId, searchRequest, pageRequest);
+                    .search(uketEventId, uketEventRoundId, searchRequest, pageRequest);
             }
 
         val response = CustomPageResponse(TicketSearchResponse.from(tickets))

--- a/src/main/kotlin/api/admin/AdminTicketController.kt
+++ b/src/main/kotlin/api/admin/AdminTicketController.kt
@@ -63,12 +63,14 @@ class AdminTicketController(
     @Operation(summary = "실시간 입장 내역 조회 API", description = "실시간 입장내역 조회를 합니다. 페이지는 1Page부터 시작합니다.")
     @GetMapping("/live/enter-users/{uketEventId}")
     fun searchLiveEnterUsers(
+        @RequestParam(required = false) uketEventRoundId: Long?,
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
         @PathVariable("uketEventId") uketEventId: Long,
     ): ResponseEntity<CustomPageResponse<LiveEnterUserResponse>> {
         val response = enterUketEventFacade.searchLiveEnterUsers(
             uketEventId,
+            uketEventRoundId,
             PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "modifiedAt"))
         )
         return ResponseEntity.ok(CustomPageResponse(response))

--- a/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
+++ b/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
@@ -195,11 +195,14 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN eg.uketEventRound ur
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
-    WHERE e.id = :uketEventId AND t.status = :status
+    WHERE e.id = :uketEventId
+    AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
+    AND t.status = :status
 """
     )
     fun findLiveEnterUserDtosByUketEventAndRoundId(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("status") status: TicketStatus,
         pageable: Pageable,
     ): Page<LiveEnterUserDto>

--- a/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
+++ b/src/main/kotlin/domain/reservation/repository/TicketRepository.kt
@@ -30,11 +30,13 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+      AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
       AND t.status = :status
 """
     )
     fun findByStatus(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("status") status: TicketStatus,
         pageable: Pageable,
     ): Page<TicketSearchDto>
@@ -57,11 +59,13 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+      AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
       AND t.createdAt BETWEEN :startAt AND :endAt
 """
     )
     fun findByCreatedAtBetween(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("startAt") startAt: LocalDateTime,
         @Param("endAt") endAt: LocalDateTime,
         pageable: Pageable,
@@ -85,11 +89,13 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+      AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
       AND t.createdAt BETWEEN :startAt AND :endAt
 """
     )
     fun findByUpdatedAtBetween(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("startAt") startAt: LocalDateTime,
         @Param("endAt") endAt: LocalDateTime,
         pageable: Pageable,
@@ -115,11 +121,13 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+      AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
       AND u.name = :userName
 """
     )
     fun findByUserName(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("userName") userName: String,
         pageable: Pageable,
     ): Page<TicketSearchDto>
@@ -142,11 +150,13 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+      AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
       AND ur.eventRoundDateTime BETWEEN :startAt AND :endAt
 """
     )
     fun findByEventRoundTime(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("startAt") startAt: LocalDateTime,
         @Param("endAt") endAt: LocalDateTime,
         pageable: Pageable,
@@ -225,10 +235,12 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+    AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
 """
     )
     fun findAllByEventId(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         pageable: Pageable,
     ): Page<TicketSearchDto>
 
@@ -250,11 +262,13 @@ interface TicketRepository : JpaRepository<Ticket, Long> {
     JOIN ur.uketEvent e
     JOIN User u ON u.id = t.userId
     WHERE e.id = :uketEventId
+      AND (:uketEventRoundId IS NULL OR ur.id = :uketEventRoundId)
       AND u.phoneNumber LIKE %:lastFourDigits
 """
     )
     fun findByPhoneNumberEndingWith(
         @Param("uketEventId") uketEventId: Long,
+        @Param("uketEventRoundId") uketEventRoundId: Long?,
         @Param("lastFourDigits") lastFourDigits: String,
         pageable: Pageable,
     ): Page<TicketSearchDto>

--- a/src/main/kotlin/domain/reservation/service/TicketService.kt
+++ b/src/main/kotlin/domain/reservation/service/TicketService.kt
@@ -38,8 +38,8 @@ class TicketService(
         return ticketRepository.findLiveEnterUserDtosByUketEventAndRoundId(uketEventId, uketEventRoundId, TicketStatus.FINISH_ENTER, pageable)
     }
 
-    fun searchAllTickets(eventId: Long, pageable: Pageable): Page<TicketSearchDto> {
-        return ticketRepository.findAllByEventId(eventId, pageable)
+    fun searchAllTickets(eventId: Long, uketEventRoundId: Long?, pageable: Pageable): Page<TicketSearchDto> {
+        return ticketRepository.findAllByEventId(eventId, uketEventRoundId, pageable)
     }
 
     @Transactional

--- a/src/main/kotlin/domain/reservation/service/TicketService.kt
+++ b/src/main/kotlin/domain/reservation/service/TicketService.kt
@@ -34,8 +34,8 @@ class TicketService(
         return ticketRepository.findValidTicketsByUserIdAndStatusNotIn(userId, excludedStatuses)
     }
 
-    fun findLiveEnterTickets(eventId: Long, pageable: Pageable): Page<LiveEnterUserDto> {
-        return ticketRepository.findLiveEnterUserDtosByUketEventAndRoundId(eventId, TicketStatus.FINISH_ENTER, pageable)
+    fun findLiveEnterTickets(uketEventId: Long, uketEventRoundId: Long?, pageable: Pageable): Page<LiveEnterUserDto> {
+        return ticketRepository.findLiveEnterUserDtosByUketEventAndRoundId(uketEventId, uketEventRoundId, TicketStatus.FINISH_ENTER, pageable)
     }
 
     fun searchAllTickets(eventId: Long, pageable: Pageable): Page<TicketSearchDto> {

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcher.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcher.kt
@@ -8,7 +8,7 @@ import uket.domain.reservation.dto.TicketSearchDto
 import uket.domain.reservation.repository.TicketRepository
 
 interface SearchTicket {
-    fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto>
+    fun search(uketEventId: Long, uketEventRoundId: Long?, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto>
 }
 
 abstract class TicketSearcher(

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByCreatedAt.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByCreatedAt.kt
@@ -19,13 +19,18 @@ class TicketSearcherByCreatedAt(
     }
 
     @Transactional(readOnly = true)
-    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+    override fun search(
+        uketEventId: Long,
+        uketEventRoundId: Long?,
+        searchRequest: SearchRequest,
+        pageable: Pageable,
+    ): Page<TicketSearchDto> {
         val createdAt = searchRequest.createdAt
             ?: throw IllegalStateException("createdAt은 null일 수 없습니다.")
 
         val createStart = createdAt.toLocalDate().atTime(LocalTime.MIN)
         val createEnd = createdAt.toLocalDate().atTime(LocalTime.MAX)
 
-        return ticketRepository.findByCreatedAtBetween(uketEventId, createStart, createEnd, pageable)
+        return ticketRepository.findByCreatedAtBetween(uketEventId, uketEventRoundId, createStart, createEnd, pageable)
     }
 }

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByEventRoundDateTime.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByEventRoundDateTime.kt
@@ -20,13 +20,18 @@ class TicketSearcherByEventRoundDateTime(
     }
 
     @Transactional(readOnly = true)
-    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+    override fun search(
+        uketEventId: Long,
+        uketEventRoundId: Long?,
+        searchRequest: SearchRequest,
+        pageable: Pageable,
+    ): Page<TicketSearchDto> {
         val showDate = searchRequest.showDate
             ?: throw IllegalStateException("showDate가 null일 수 없습니다.")
 
         val showStart: LocalDateTime = showDate.atStartOfDay()
         val showEnd: LocalDateTime = showDate.atTime(LocalTime.MAX)
 
-        return ticketRepository.findByEventRoundTime(uketEventId, showStart, showEnd, pageable);
+        return ticketRepository.findByEventRoundTime(uketEventId, uketEventRoundId, showStart, showEnd, pageable);
     }
 }

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByModifiedAt.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByModifiedAt.kt
@@ -19,13 +19,18 @@ class TicketSearcherByModifiedAt(
     }
 
     @Transactional(readOnly = true)
-    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
+    override fun search(
+        uketEventId: Long,
+        uketEventRoundId: Long?,
+        searchRequest: SearchRequest,
+        pageable: Pageable,
+    ): Page<TicketSearchDto> {
         val modifiedAt = searchRequest.modifiedAt
             ?: throw IllegalStateException("modifiedAt은 null일 수 없습니다.")
 
         val modifyStart = modifiedAt.toLocalDate().atTime(LocalTime.MIN)
         val modifyEnd = modifiedAt.toLocalDate().atTime(LocalTime.MAX)
 
-        return ticketRepository.findByUpdatedAtBetween(uketEventId, modifyStart, modifyEnd, pageable)
+        return ticketRepository.findByUpdatedAtBetween(uketEventId, uketEventRoundId, modifyStart, modifyEnd, pageable)
     }
 }

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByPhoneNumber.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByPhoneNumber.kt
@@ -18,7 +18,12 @@ class TicketSearcherByPhoneNumber(
     }
 
     @Transactional(readOnly = true)
-    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
-        return ticketRepository.findByPhoneNumberEndingWith(uketEventId, searchRequest.phoneNumberLastFourDigits!!, pageable)
+    override fun search(
+        uketEventId: Long,
+        uketEventRoundId: Long?,
+        searchRequest: SearchRequest,
+        pageable: Pageable,
+    ): Page<TicketSearchDto> {
+        return ticketRepository.findByPhoneNumberEndingWith(uketEventId, uketEventRoundId, searchRequest.phoneNumberLastFourDigits!!, pageable)
     }
 }

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByStatus.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByStatus.kt
@@ -18,7 +18,12 @@ class TicketSearcherByStatus(
     }
 
     @Transactional(readOnly = true)
-    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
-        return ticketRepository.findByStatus(uketEventId, searchRequest.status!!, pageable)
+    override fun search(
+        uketEventId: Long,
+        uketEventRoundId: Long?,
+        searchRequest: SearchRequest,
+        pageable: Pageable,
+    ): Page<TicketSearchDto> {
+        return ticketRepository.findByStatus(uketEventId, uketEventRoundId, searchRequest.status!!, pageable)
     }
 }

--- a/src/main/kotlin/domain/reservation/service/search/TicketSearcherByUserName.kt
+++ b/src/main/kotlin/domain/reservation/service/search/TicketSearcherByUserName.kt
@@ -18,7 +18,12 @@ class TicketSearcherByUserName(
     }
 
     @Transactional(readOnly = true)
-    override fun search(uketEventId: Long, searchRequest: SearchRequest, pageable: Pageable): Page<TicketSearchDto> {
-        return ticketRepository.findByUserName(uketEventId, searchRequest.userName!!, pageable)
+    override fun search(
+        uketEventId: Long,
+        uketEventRoundId: Long?,
+        searchRequest: SearchRequest,
+        pageable: Pageable,
+    ): Page<TicketSearchDto> {
+        return ticketRepository.findByUserName(uketEventId, uketEventRoundId, searchRequest.userName!!, pageable)
     }
 }

--- a/src/main/kotlin/facade/EnterUketEventFacade.kt
+++ b/src/main/kotlin/facade/EnterUketEventFacade.kt
@@ -41,8 +41,8 @@ class EnterUketEventFacade(
     }
 
     @Transactional(readOnly = true)
-    fun searchLiveEnterUsers(uketEventId: Long, pageable: Pageable): Page<LiveEnterUserResponse> {
-        val liveEnterUserDto: Page<LiveEnterUserDto> = ticketService.findLiveEnterTickets(uketEventId, pageable)
+    fun searchLiveEnterUsers(uketEventId: Long, uketEventRoundId: Long?, pageable: Pageable): Page<LiveEnterUserResponse> {
+        val liveEnterUserDto: Page<LiveEnterUserDto> = ticketService.findLiveEnterTickets(uketEventId, uketEventRoundId, pageable)
         return liveEnterUserDto.map { dto -> LiveEnterUserResponse.from(dto) }
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -54,7 +54,7 @@ app:
   token:
     secret-key: ${JWT_SECRET_KEY}
     expiration:
-      access-token-expiration: 600_000
+      access-token-expiration: 7_200_000
       refresh-token-expiration: 7_200_000
       email-token-expiration: 86_400_000
       ticket-token-expiration: 1_200_000


### PR DESCRIPTION
# 📌 개요
- 어드민 필터 조회시 uketEventRoundId를 통해 filtering 하는 부분이 누락되어있어 추가했습니다.

# 💻 작업사항
- [x] uketEventRoundId를 받아 ticket 결과값 필터링 구현

# ❌ 주의사항
- pathVariable required=false를 통해 nullable 옵션이 repository코드까지 퍼져 추후에 개선 예정
- 단일 객체에 대한 필털링만 적용 가능해 복수 적용 가능한 filtering으로 추후 개선 예정

# 💡 코드 리뷰 요청사항
- 현재 기능 구현을 우선적으로 진행해야해서 pathVariable통해 단일 filtering만 가능하게 급하게 구현해두었는데, 혹시 더 나은 방안이나 복수 filtering 구현 방안에 대해 좋은 아이디어 있다면 말씀해주시면 감사하겠습니다!
