### PR TITLE
[UKET-107] 회차/그룹 조회 API migration

### DIFF
--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -72,7 +72,7 @@ class EventController(
         val uketEvent = uketEventRound.uketEvent!!
         uketEvent.validateNowTicketing(now)
 
-        val entryGroups = entryGroupService.findValidByUketEventRoundId(eventRoundId)
+        val entryGroups = entryGroupService.findValidByUketEventRoundIdAfter(eventRoundId, now)
         val responses = entryGroups.map { EntryGroupListItemResponse.of(it) }
         return ResponseEntity.ok(ListResponse(responses))
     }

--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -10,14 +10,23 @@ import org.springframework.web.bind.annotation.RestController
 import uket.api.user.request.EventListQueryType
 import uket.api.user.response.ActiveEventsResponse
 import uket.api.user.response.EventDetailResponse
+import uket.auth.config.userId.LoginUserId
+import uket.common.response.ListResponse
+import uket.domain.uketevent.service.EntryGroupService
+import uket.domain.uketevent.service.UketEventRoundService
 import uket.domain.uketevent.service.UketEventService
+import uket.uket.api.user.response.EntryGroupListItemResponse
+import uket.uket.api.user.response.EventRoundListItemResponse
+import java.time.LocalDateTime
 
 @Tag(name = "행사 관련 API", description = "행사 관련 API 입니다")
 @RestController
 class EventController(
-    val uketEventService: UketEventService,
+    private val uketEventService: UketEventService,
+    private val entryGroupService: EntryGroupService,
+    private val uketEventRoundService: UketEventRoundService,
 ) {
-    @Operation(summary = "활성화된 행사 목록 조회", description = "유저가 조회 가능한 행사 목록을 가져옵니다")
+    @Operation(summary = "활성화된 행사 목록 조회", description = "누구나 조회 가능한 행사 목록을 가져옵니다")
     @GetMapping("/uket-events")
     fun getEvents(
         @RequestParam("type") type: EventListQueryType,
@@ -26,12 +35,45 @@ class EventController(
         return ResponseEntity.ok(ActiveEventsResponse(itemList))
     }
 
-    @Operation(summary = "행사 상세 정보 조회", description = "유저가 조회 가능한 행사의 상세 정보를 가져옵니다")
+    @Operation(summary = "행사 상세 정보 조회", description = "누구나 조회 가능한 행사의 상세 정보를 가져옵니다")
     @GetMapping("/uket-events/{id}")
     fun getEvents(
         @PathVariable("id") eventId: Long,
     ): ResponseEntity<EventDetailResponse> {
         val event = uketEventService.getDetailById(eventId)
         return ResponseEntity.ok(EventDetailResponse.from(event))
+    }
+
+    @Operation(summary = "행사 회차 목록 조회", description = "유저가 예매 가능한 행사의 현재 날짜와 이후 회차 목록을 가져옵니다")
+    @GetMapping("/uket-events/{id}/rounds")
+    fun getEventRounds(
+        @LoginUserId userId: Long,
+        @PathVariable("id") eventId: Long,
+    ): ResponseEntity<ListResponse<EventRoundListItemResponse>> {
+        val now = LocalDateTime.now()
+
+        val event = uketEventService.getById(eventId)
+        event.validateNowTicketing(now)
+
+        val eventRounds = uketEventRoundService.findByUketEventIdAndDateAfter(eventId, now)
+        val responses = eventRounds.map { EventRoundListItemResponse.of(it) }
+        return ResponseEntity.ok(ListResponse(responses))
+    }
+
+    @Operation(summary = "회차 입장 그룹 목록 조회", description = "유저가 예매 가능한 회차의 입장 그룹 목록을 가져옵니다")
+    @GetMapping("/rounds/{id}/entry-groups")
+    fun getEntryGroups(
+        @LoginUserId userId: Long,
+        @PathVariable("id") eventRoundId: Long,
+    ): ResponseEntity<ListResponse<EntryGroupListItemResponse>> {
+        val now = LocalDateTime.now()
+
+        val uketEventRound = uketEventRoundService.getByIdWithUketEvent(eventRoundId)
+        val uketEvent = uketEventRound.uketEvent!!
+        uketEvent.validateNowTicketing(now)
+
+        val entryGroups = entryGroupService.findValidByUketEventRoundId(eventRoundId)
+        val responses = entryGroups.map { EntryGroupListItemResponse.of(it) }
+        return ResponseEntity.ok(ListResponse(responses))
     }
 }

--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestController
 import uket.api.user.request.EventListQueryType
 import uket.api.user.response.ActiveEventsResponse
 import uket.api.user.response.EventDetailResponse
-import uket.auth.config.userId.LoginUserId
 import uket.common.response.ListResponse
 import uket.domain.uketevent.service.EntryGroupService
 import uket.domain.uketevent.service.UketEventRoundService
@@ -47,7 +46,6 @@ class EventController(
     @Operation(summary = "행사 회차 목록 조회", description = "유저가 예매 가능한 행사의 현재 날짜와 이후 회차 목록을 가져옵니다")
     @GetMapping("/uket-events/{id}/rounds")
     fun getEventRounds(
-        @LoginUserId userId: Long,
         @PathVariable("id") eventId: Long,
     ): ResponseEntity<ListResponse<EventRoundListItemResponse>> {
         val now = LocalDateTime.now()
@@ -63,7 +61,6 @@ class EventController(
     @Operation(summary = "회차 입장 그룹 목록 조회", description = "유저가 예매 가능한 회차의 입장 그룹 목록을 가져옵니다")
     @GetMapping("/rounds/{id}/entry-groups")
     fun getEntryGroups(
-        @LoginUserId userId: Long,
         @PathVariable("id") eventRoundId: Long,
     ): ResponseEntity<ListResponse<EntryGroupListItemResponse>> {
         val now = LocalDateTime.now()

--- a/src/main/kotlin/uket/api/user/response/EntryGroupListItemResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/EntryGroupListItemResponse.kt
@@ -1,0 +1,22 @@
+package uket.uket.api.user.response
+
+import uket.domain.uketevent.entity.EntryGroup
+import java.time.LocalDateTime
+
+data class EntryGroupListItemResponse(
+    val entryGroupId: Long,
+    val name: String,
+    val startDateTime: LocalDateTime,
+    val ticketCount: Int,
+    val totalTicketCount: Int,
+) {
+    companion object {
+        fun of(entryGroup: EntryGroup): EntryGroupListItemResponse = EntryGroupListItemResponse(
+            entryGroupId = entryGroup.id,
+            name = entryGroup.entryGroupName,
+            startDateTime = entryGroup.entryStartDateTime,
+            ticketCount = entryGroup.ticketCount,
+            totalTicketCount = entryGroup.totalTicketCount
+        )
+    }
+}

--- a/src/main/kotlin/uket/api/user/response/EventRoundListItemResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/EventRoundListItemResponse.kt
@@ -1,0 +1,19 @@
+package uket.uket.api.user.response
+
+import uket.domain.uketevent.entity.UketEventRound
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+data class EventRoundListItemResponse(
+    val eventRoundId: Long,
+    val eventRoundDateTime: LocalDateTime,
+    val weekDay: DayOfWeek,
+) {
+    companion object {
+        fun of(eventRound: UketEventRound): EventRoundListItemResponse = EventRoundListItemResponse(
+            eventRoundId = eventRound.id,
+            eventRoundDateTime = eventRound.eventRoundDateTime,
+            weekDay = eventRound.eventRoundDateTime.dayOfWeek
+        )
+    }
+}

--- a/src/main/kotlin/uket/auth/config/AuthConfig.kt
+++ b/src/main/kotlin/uket/auth/config/AuthConfig.kt
@@ -25,6 +25,8 @@ class AuthConfig(
             .excludePathPatterns("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs", "/error")
             .excludePathPatterns("/admin/users/login")
             .excludePathPatterns("/auth/**")
+            .addPathPatterns("/uket-events/*/rounds/**")
+            .addPathPatterns("/rounds/*/entry-groups/**")
             .excludePathPatterns("/uket-events/**")
             .excludePathPatterns("/users/register")
             .excludePathPatterns("/terms/**")

--- a/src/main/kotlin/uket/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/uket/auth/config/SecurityConfig.kt
@@ -67,10 +67,14 @@ class SecurityConfig(
                     .permitAll()
             }.authorizeHttpRequests { registry ->
                 registry // actuator, rest docs 경로, 실무에서는 상황에 따라 적절한 접근제어 필요
-                    .requestMatchers("/actuator/*").permitAll()
-                    .requestMatchers("/swagger-ui.html").permitAll()
-                    .requestMatchers("/swagger-ui/**").permitAll()
-                    .requestMatchers("/v3/api-docs/**").permitAll()
+                    .requestMatchers("/actuator/*")
+                    .permitAll()
+                    .requestMatchers("/swagger-ui.html")
+                    .permitAll()
+                    .requestMatchers("/swagger-ui/**")
+                    .permitAll()
+                    .requestMatchers("/v3/api-docs/**")
+                    .permitAll()
             }.authorizeHttpRequests { registry ->
                 registry
                     .requestMatchers("/api/v1/auth")
@@ -89,6 +93,10 @@ class SecurityConfig(
                     .permitAll()
                     .requestMatchers("/auth/**")
                     .permitAll()
+                    .requestMatchers("/uket-events/*/rounds/**")
+                    .authenticated()
+                    .requestMatchers("/rounds/*/entry-groups/**")
+                    .authenticated()
                     .requestMatchers("/uket-events/**")
                     .permitAll()
             }.authorizeHttpRequests { registry ->

--- a/src/main/kotlin/uket/domain/uketevent/entity/EntryGroup.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/EntryGroup.kt
@@ -20,8 +20,8 @@ class EntryGroup(
     val id: Long = 0L,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "uket_event_round_id", nullable = false)
-    val uketEventRound: UketEventRound,
+    @JoinColumn(name = "uket_event_round_id")
+    var uketEventRound: UketEventRound,
 
     @Column(name = "entry_group_name")
     val entryGroupName: String,

--- a/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
@@ -13,8 +13,10 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import uket.common.PublicException
 import uket.common.enums.EventType
 import uket.domain.BaseTimeEntity
+import uket.domain.uketevent.enums.TicketingStatus
 import java.time.LocalDateTime
 
 @Entity
@@ -116,6 +118,28 @@ class UketEvent(
         enum class ContactType {
             INSTAGRAM,
             KAKAO,
+        }
+    }
+
+    fun getTicketingStatusFrom(now: LocalDateTime): TicketingStatus {
+        var ticketingStatus = TicketingStatus.오픈_예정
+        if (now.isAfter(this.ticketingStartDateTime)) {
+            ticketingStatus = TicketingStatus.티켓팅_진행중
+        }
+        if (now.isAfter(this.ticketingEndDateTime)) {
+            ticketingStatus = TicketingStatus.티켓팅_종료
+        }
+        return ticketingStatus
+    }
+
+    fun validateNowTicketing(now: LocalDateTime) {
+        val ticketingStatus = this.getTicketingStatusFrom(now)
+        if (ticketingStatus != TicketingStatus.티켓팅_진행중) {
+            throw PublicException(
+                publicMessage = "예매가 불가능 한 행사입니다",
+                systemMessage = "[UketEventService] 티켓팅이 진행 중이지 않은 행사 validation",
+                title = "예매 불가능 한 행사"
+            )
         }
     }
 }

--- a/src/main/kotlin/uket/domain/uketevent/repository/EntryGroupRepository.kt
+++ b/src/main/kotlin/uket/domain/uketevent/repository/EntryGroupRepository.kt
@@ -1,8 +1,16 @@
 package uket.domain.uketevent.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import uket.domain.uketevent.entity.EntryGroup
+import java.time.LocalDateTime
 
 interface EntryGroupRepository : JpaRepository<EntryGroup, Long> {
-    fun <T> findByUketEventRoundId(uketEventRoundId: Long, type: Class<T>): List<T>
+    @Query(
+        """
+            SELECT eg FROM EntryGroup eg
+            WHERE eg.entryStartDateTime >= :at
+        """
+    )
+    fun findByUketEventRoundIdAfter(uketEventRoundId: Long, at: LocalDateTime): List<EntryGroup>
 }

--- a/src/main/kotlin/uket/domain/uketevent/repository/UketEventRoundRepository.kt
+++ b/src/main/kotlin/uket/domain/uketevent/repository/UketEventRoundRepository.kt
@@ -1,8 +1,26 @@
 package uket.domain.uketevent.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import uket.domain.uketevent.entity.UketEventRound
+import java.time.LocalDateTime
 
 interface UketEventRoundRepository : JpaRepository<UketEventRound, Long> {
-    fun <T> findByUketEventId(uketEventId: Long, type: Class<T>): List<T>
+    @Query(
+        """
+            SELECT uer FROM UketEventRound uer
+            JOIN uer.uketEvent ue ON ue.id = :uketEventId
+            WHERE uer.eventRoundDateTime >= :date
+        """
+    )
+    fun findByUketEventIdAAndEventRoundDateAfter(uketEventId: Long, date: LocalDateTime): List<UketEventRound>
+
+    @Query(
+        """
+            SELECT uer FROM UketEventRound uer
+            JOIN FETCH uer.uketEvent ue
+            WHERE uer.id = :uketEventRoundId
+        """
+    )
+    fun findByIdWithUketEvent(uketEventRoundId: Long): UketEventRound?
 }

--- a/src/main/kotlin/uket/domain/uketevent/service/EntryGroupService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/EntryGroupService.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import uket.domain.uketevent.entity.EntryGroup
 import uket.domain.uketevent.repository.EntryGroupRepository
 import uket.modules.redis.aop.DistributedLock
+import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
@@ -18,8 +19,8 @@ class EntryGroupService(
         return entryGroup
     }
 
-    fun findValidByUketEventRoundId(uketEventRoundId: Long): List<EntryGroup> {
-        val entryGroups = entryGroupRepository.findByUketEventRoundId(uketEventRoundId, EntryGroup::class.java)
+    fun findValidByUketEventRoundIdAfter(uketEventRoundId: Long, at: LocalDateTime): List<EntryGroup> {
+        val entryGroups = entryGroupRepository.findByUketEventRoundIdAfter(uketEventRoundId, at)
         return entryGroups.mapNotNull { if (it.ticketCount >= it.totalTicketCount) null else it }
     }
 

--- a/src/main/kotlin/uket/domain/uketevent/service/EntryGroupService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/EntryGroupService.kt
@@ -18,8 +18,10 @@ class EntryGroupService(
         return entryGroup
     }
 
-    fun findByUketEventRoundId(uketEventRoundId: Long): List<EntryGroup> =
-        entryGroupRepository.findByUketEventRoundId(uketEventRoundId, EntryGroup::class.java)
+    fun findValidByUketEventRoundId(uketEventRoundId: Long): List<EntryGroup> {
+        val entryGroups = entryGroupRepository.findByUketEventRoundId(uketEventRoundId, EntryGroup::class.java)
+        return entryGroups.mapNotNull { if (it.ticketCount >= it.totalTicketCount) null else it }
+    }
 
     @Transactional
     fun increaseReservedCount(entryGroupId: Long) {

--- a/src/main/kotlin/uket/domain/uketevent/service/UketEventRoundService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/UketEventRoundService.kt
@@ -4,14 +4,14 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uket.domain.uketevent.entity.UketEventRound
-import uket.domain.uketevent.repository.UketEventRepository
 import uket.domain.uketevent.repository.UketEventRoundRepository
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @Service
 @Transactional(readOnly = true)
 class UketEventRoundService(
     private val uketEventRoundRepository: UketEventRoundRepository,
-    private val uketEventRepository: UketEventRepository,
 ) {
     fun getById(uketEventRoundId: Long): UketEventRound {
         val uketEventRound = uketEventRoundRepository.findByIdOrNull(uketEventRoundId)
@@ -19,6 +19,12 @@ class UketEventRoundService(
         return uketEventRound
     }
 
-    fun findByUketEventId(uketEventId: Long): List<UketEventRound> =
-        uketEventRoundRepository.findByUketEventId(uketEventId, UketEventRound::class.java)
+    fun getByIdWithUketEvent(uketEventRoundId: Long): UketEventRound {
+        val uketEventRound = uketEventRoundRepository.findByIdWithUketEvent(uketEventRoundId)
+            ?: throw IllegalStateException("해당 회차를 찾을 수 없습니다.")
+        return uketEventRound
+    }
+
+    fun findByUketEventIdAndDateAfter(uketEventId: Long, date: LocalDateTime): List<UketEventRound> =
+        uketEventRoundRepository.findByUketEventIdAAndEventRoundDateAfter(uketEventId, date.truncatedTo(ChronoUnit.DAYS))
 }

--- a/src/main/kotlin/uket/domain/uketevent/service/UketEventService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/UketEventService.kt
@@ -8,7 +8,6 @@ import uket.common.LoggerDelegate
 import uket.common.enums.EventType
 import uket.domain.uketevent.dto.EventListItem
 import uket.domain.uketevent.entity.UketEvent
-import uket.domain.uketevent.enums.TicketingStatus
 import uket.domain.uketevent.repository.UketEventRepository
 import java.time.LocalDateTime
 
@@ -46,7 +45,7 @@ class UketEventService(
         val now = LocalDateTime.now()
         val itemList = eventList
             .map {
-                val ticketingStatus = getCurrentEventTicketingStatus(now, it)
+                val ticketingStatus = it.getTicketingStatusFrom(now)
                 EventListItem.of(it, ticketingStatus)
             }
         val orderedList = itemList.sortedWith(
@@ -57,20 +56,6 @@ class UketEventService(
         val endTime = System.currentTimeMillis()
         log.debug("[UketEventService.getActiveEventItemList] 메서드 실행 시간 : {}", endTime - startTime)
         return orderedList
-    }
-
-    private fun getCurrentEventTicketingStatus(
-        now: LocalDateTime,
-        it: UketEvent,
-    ): TicketingStatus {
-        var ticketingStatus = TicketingStatus.오픈_예정
-        if (now.isAfter(it.ticketingStartDateTime)) {
-            ticketingStatus = TicketingStatus.티켓팅_진행중
-        }
-        if (now.isAfter(it.ticketingEndDateTime)) {
-            ticketingStatus = TicketingStatus.티켓팅_종료
-        }
-        return ticketingStatus
     }
 
     @Transactional(readOnly = true)

--- a/src/test/kotlin/uket/domain/uketEvent/EntryGroupServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/EntryGroupServiceTest.kt
@@ -22,20 +22,19 @@ class EntryGroupServiceTest :
 
         describe("입장 그룹 목록 조회") {
             context("입장 그룹 하나는 지금, 하나는 티켓 품절, 하나는 한 시간 뒤일 때") {
-                val (uketEvent, uketEventRound, entryGroups) = setDB()
-                every { entryGroupRepository.findByUketEventRoundId(uketEventRound.id, EntryGroup::class.java) } returns entryGroups
+                val now = LocalDateTime.now()
+                val (uketEvent, uketEventRound, entryGroups) = setDB(now)
+                every { entryGroupRepository.findByUketEventRoundIdAfter(uketEventRound.id, now) } returns entryGroups
 
                 it("입장 그룹 1개만 출력") {
-                    val findEntryGroups = entryGroupService.findValidByUketEventRoundId(uketEventRound.id)
+                    val findEntryGroups = entryGroupService.findValidByUketEventRoundIdAfter(uketEventRound.id, now)
                     findEntryGroups.size shouldBe 1
                 }
             }
         }
     }) {
     companion object {
-        private fun setDB(): Triple<UketEvent, UketEventRound, List<EntryGroup>> {
-            val now = LocalDateTime.now()
-
+        private fun setDB(now: LocalDateTime): Triple<UketEvent, UketEventRound, List<EntryGroup>> {
             val uketEventRounds =
                 UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(7)))
 

--- a/src/test/kotlin/uket/domain/uketEvent/EntryGroupServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/EntryGroupServiceTest.kt
@@ -1,0 +1,56 @@
+package uket.domain.uketEvent
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import uket.domain.uketevent.entity.EntryGroup
+import uket.domain.uketevent.entity.UketEvent
+import uket.domain.uketevent.entity.UketEventRound
+import uket.domain.uketevent.repository.EntryGroupRepository
+import uket.domain.uketevent.service.EntryGroupService
+import java.time.LocalDateTime
+
+class EntryGroupServiceTest :
+    DescribeSpec({
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val entryGroupRepository: EntryGroupRepository = mockk<EntryGroupRepository>()
+        val entryGroupService: EntryGroupService = EntryGroupService(entryGroupRepository)
+
+        describe("입장 그룹 목록 조회") {
+            context("입장 그룹 하나는 지금, 하나는 티켓 품절, 하나는 한 시간 뒤일 때") {
+                val (uketEvent, uketEventRound, entryGroups) = setDB()
+                every { entryGroupRepository.findByUketEventRoundId(uketEventRound.id, EntryGroup::class.java) } returns entryGroups
+
+                it("입장 그룹 1개만 출력") {
+                    val findEntryGroups = entryGroupService.findValidByUketEventRoundId(uketEventRound.id)
+                    findEntryGroups.size shouldBe 1
+                }
+            }
+        }
+    }) {
+    companion object {
+        private fun setDB(): Triple<UketEvent, UketEventRound, List<EntryGroup>> {
+            val now = LocalDateTime.now()
+
+            val uketEventRounds =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(7)))
+
+            val uketEvent = UketEventRandomUtil.createUketEvent(
+                now.minusDays(2),
+                now.plusDays(2),
+                uketEventRounds,
+                listOf()
+            )
+
+            val entryGroups = UketEventRandomUtil.createEntryGroupWithTime(uketEventRounds[0], listOf(now.minusHours(1), now, now.plusHours(1)))
+            entryGroups[1].totalTicketCount = 0
+            entryGroups[1].ticketCount = 0
+
+            return Triple(uketEvent, uketEventRounds[0], listOf(entryGroups[1], entryGroups[2]))
+        }
+    }
+}

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
@@ -69,6 +69,27 @@ class UketEventRandomUtil {
             return eventRounds
         }
 
+        fun createEntryGroupWithTime(
+            uketEventRound: UketEventRound,
+            entryGroupStartTimes: List<LocalDateTime>,
+        ): List<EntryGroup> {
+            val entryGroups = entryGroupStartTimes.map {
+                val easyRandomEntryGroup = EasyRandom(
+                    EasyRandomParameters()
+                        .randomize(named("id")) { 0L }
+                        .randomize(named("entryStartDateTime")) { it }
+                        .randomize(named("entryEndDateTime")) { it.plusMinutes(10) }
+                        .randomize(named("ticketCount")) { 0 }
+                        .randomize(named("totalTicketCount")) { 10 }
+                )
+                easyRandomEntryGroup.nextObject(EntryGroup::class.java)
+            }
+
+            entryGroups.forEach { it.uketEventRound = uketEventRound }
+
+            return entryGroups
+        }
+
         fun createDummyData() {
             val now = LocalDateTime.now()
             val events = mutableListOf<UketEvent>()
@@ -174,27 +195,6 @@ class UketEventRandomUtil {
             }
 
             return eventRounds
-        }
-
-        private fun createEntryGroupWithTime(
-            uketEventRound: UketEventRound,
-            entryGroupStartTimes: List<LocalDateTime>,
-        ): List<EntryGroup> {
-            val entryGroups = entryGroupStartTimes.map {
-                val easyRandomEntryGroup = EasyRandom(
-                    EasyRandomParameters()
-                        .randomize(named("id")) { 0L }
-                        .randomize(named("entryStartDateTime")) { it }
-                        .randomize(named("entryEndDateTime")) { it.plusMinutes(10) }
-                        .randomize(named("ticketCount")) { 0 }
-                        .randomize(named("totalTicketCount")) { 10 }
-                )
-                easyRandomEntryGroup.nextObject(EntryGroup::class.java)
-            }
-
-            entryGroups.forEach { it.uketEventRound = uketEventRound }
-
-            return entryGroups
         }
 
         private fun toInsertSqlForEntryGroup(entryGroup: EntryGroup): String {

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRandomUtil.kt
@@ -4,6 +4,7 @@ import org.jeasy.random.EasyRandom
 import org.jeasy.random.EasyRandomParameters
 import org.jeasy.random.FieldPredicates.named
 import uket.domain.uketevent.entity.Banner
+import uket.domain.uketevent.entity.EntryGroup
 import uket.domain.uketevent.entity.UketEvent
 import uket.domain.uketevent.entity.UketEventRound
 import java.time.LocalDateTime
@@ -11,7 +12,7 @@ import kotlin.random.Random
 
 class UketEventRandomUtil {
     companion object {
-        fun createUketEventWithDatesAndEventRoundsAndBanners(
+        fun createUketEvent(
             ticketingStartDateTime: LocalDateTime,
             ticketingEndDateTime: LocalDateTime,
             uketEventRounds: List<UketEventRound>,
@@ -19,9 +20,8 @@ class UketEventRandomUtil {
         ): UketEvent {
             val easyRandom = EasyRandom(
                 EasyRandomParameters()
-                    .randomize(named("id")) {
-                        0L
-                    }.randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
+                    .randomize(named("id")) { 0L }
+                    .randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
                     .randomize(named("ticketingEndDateTime")) { ticketingEndDateTime }
                     .randomize(named("banners")) {
                         banners.map {
@@ -53,44 +53,7 @@ class UketEventRandomUtil {
             return uketEvent
         }
 
-        fun createUketEventWithDatesAndNameAndIdAndEventRounds(
-            ticketingStartDateTime: LocalDateTime,
-            ticketingEndDateTime: LocalDateTime,
-            eventName: String,
-            id: Long,
-            uketEventRounds: List<UketEventRound>,
-        ): UketEvent {
-            val easyRandom = EasyRandom(
-                EasyRandomParameters()
-                    .randomize(named("id")) {
-                        id
-                    }.randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
-                    .randomize(named("ticketingEndDateTime")) { ticketingEndDateTime }
-                    .randomize(named("eventName")) {
-                        eventName
-                    }.randomize(named("banners")) {
-                        listOf<Banner>()
-                    }.randomize(named("uketEventRounds")) {
-                        uketEventRounds.map {
-                            UketEventRound(
-                                id = it.id,
-                                uketEvent = null,
-                                eventRoundDateTime = it.eventRoundDateTime
-                            )
-                        }
-                    }.randomize(named("firstRoundDateTime")) {
-                        uketEventRounds.minOf { it.eventRoundDateTime }
-                    }.randomize(named("lastRoundDateTime")) {
-                        uketEventRounds.maxOf { it.eventRoundDateTime }
-                    }
-            )
-            val uketEvent = easyRandom.nextObject(UketEvent::class.java)
-            uketEvent.uketEventRounds.forEach { it.uketEvent = uketEvent }
-
-            return uketEvent
-        }
-
-        fun createUketEventsRoundWithDate(
+        fun createUketEventsRoundsWithDate(
             uketEventRoundDates: List<LocalDateTime>,
         ): List<UketEventRound> {
             val eventRounds = uketEventRoundDates.map {
@@ -110,8 +73,10 @@ class UketEventRandomUtil {
             val now = LocalDateTime.now()
             val events = mutableListOf<UketEvent>()
             val rounds = mutableListOf<UketEventRound>()
+            val groups = mutableListOf<EntryGroup>()
+            var roundStartId = 0
 
-            repeat(100) { i ->
+            repeat(10) { i ->
                 val ticketingStart = now.plusDays(Random.nextLong(-10, 10))
                 val ticketingEnd = now.plusDays(Random.nextLong(0, 3))
 
@@ -121,9 +86,10 @@ class UketEventRandomUtil {
                 repeat(roundSize) { s ->
                     roundDateTimeList.add(roundDate.plusDays(s.toLong()))
                 }
-                val uketEventRounds = createUketEventsRoundWithDate(roundDateTimeList)
+                val uketEventRounds = createUketEventsRoundsWithDateAndId(roundDateTimeList, roundStartId.toLong())
+                roundStartId += uketEventRounds.size
 
-                val event = createUketEventWithDatesAndNameAndIdAndEventRounds(
+                val event = createUketEventWithNameAndId(
                     ticketingStart,
                     ticketingEnd,
                     "행사$i",
@@ -135,6 +101,12 @@ class UketEventRandomUtil {
                 rounds.addAll(event.uketEventRounds)
             }
 
+            rounds.forEach {
+                val entryGroups =
+                    createEntryGroupWithTime(it, listOf(it.eventRoundDateTime, it.eventRoundDateTime.plusHours(1)))
+                groups.addAll(entryGroups)
+            }
+
             println("-- Insert Events")
             events.forEach {
                 println(toInsertSqlForUketEvent(it))
@@ -144,9 +116,123 @@ class UketEventRandomUtil {
             rounds.forEach {
                 println(toInsertSqlForUketEventRound(it))
             }
+
+            println("-- Insert Entry Groups")
+            groups.forEach {
+                println(toInsertSqlForEntryGroup(it))
+            }
         }
 
-        fun toInsertSqlForUketEventRound(uketEventRound: UketEventRound): String {
+        private fun createUketEventWithNameAndId(
+            ticketingStartDateTime: LocalDateTime,
+            ticketingEndDateTime: LocalDateTime,
+            eventName: String,
+            id: Long,
+            uketEventRounds: List<UketEventRound>,
+        ): UketEvent {
+            val easyRandom = EasyRandom(
+                EasyRandomParameters()
+                    .randomize(named("id")) { id }
+                    .randomize(named("eventName")) { eventName }
+                    .randomize(named("ticketingStartDateTime")) { ticketingStartDateTime }
+                    .randomize(named("ticketingEndDateTime")) { ticketingEndDateTime }
+                    .randomize(named("banners")) { listOf<Banner>() }
+                    .randomize(named("uketEventRounds")) {
+                        uketEventRounds.map {
+                            UketEventRound(
+                                id = it.id,
+                                uketEvent = null,
+                                eventRoundDateTime = it.eventRoundDateTime
+                            )
+                        }
+                    }.randomize(named("firstRoundDateTime")) {
+                        uketEventRounds.minOf { it.eventRoundDateTime }
+                    }.randomize(named("lastRoundDateTime")) {
+                        uketEventRounds.maxOf { it.eventRoundDateTime }
+                    }
+            )
+            val uketEvent = easyRandom.nextObject(UketEvent::class.java)
+            uketEvent.uketEventRounds.forEach { it.uketEvent = uketEvent }
+
+            return uketEvent
+        }
+
+        private fun createUketEventsRoundsWithDateAndId(
+            uketEventRoundDates: List<LocalDateTime>,
+            startId: Long = 0L,
+        ): List<UketEventRound> {
+            var id = startId
+            val eventRounds = uketEventRoundDates.map {
+                id += 1
+                val easyRandomEventRound = EasyRandom(
+                    EasyRandomParameters()
+                        .randomize(named("id")) { id }
+                        .randomize(named("uketEvent")) { null }
+                        .randomize(named("eventRoundDateTime")) { it }
+                )
+                easyRandomEventRound.nextObject(UketEventRound::class.java)
+            }
+
+            return eventRounds
+        }
+
+        private fun createEntryGroupWithTime(
+            uketEventRound: UketEventRound,
+            entryGroupStartTimes: List<LocalDateTime>,
+        ): List<EntryGroup> {
+            val entryGroups = entryGroupStartTimes.map {
+                val easyRandomEntryGroup = EasyRandom(
+                    EasyRandomParameters()
+                        .randomize(named("id")) { 0L }
+                        .randomize(named("entryStartDateTime")) { it }
+                        .randomize(named("entryEndDateTime")) { it.plusMinutes(10) }
+                        .randomize(named("ticketCount")) { 0 }
+                        .randomize(named("totalTicketCount")) { 10 }
+                )
+                easyRandomEntryGroup.nextObject(EntryGroup::class.java)
+            }
+
+            entryGroups.forEach { it.uketEventRound = uketEventRound }
+
+            return entryGroups
+        }
+
+        private fun toInsertSqlForEntryGroup(entryGroup: EntryGroup): String {
+            val tableName = "entry_group"
+
+            val columns = mutableListOf<String>()
+            val values = mutableListOf<String>()
+
+            // 직접 필드 접근 (중첩 필드도 분해해서 처리)
+            with(entryGroup) {
+                // 일반 필드
+                columns += listOf(
+                    "uket_event_round_id",
+                    "entry_group_name",
+                    "entry_start_datetime",
+                    "entry_end_datetime",
+                    "ticket_count",
+                    "total_ticket_count",
+                    "created_at",
+                    "updated_at"
+                )
+
+                values += listOf(
+                    uketEventRound!!.id,
+                    entryGroupName,
+                    entryStartDateTime,
+                    entryEndDateTime,
+                    ticketCount,
+                    totalTicketCount,
+                    createdAt,
+                    updatedAt
+                ).map { toSqlValue(it) }
+            }
+
+            return "INSERT INTO $tableName (${columns.joinToString(", ")}) VALUES (${values.joinToString(", ")});"
+        }
+
+        private fun toInsertSqlForUketEventRound(uketEventRound: UketEventRound): String {
             val tableName = "uket_event_round"
 
             val columns = mutableListOf<String>()
@@ -173,7 +259,7 @@ class UketEventRandomUtil {
             return "INSERT INTO $tableName (${columns.joinToString(", ")}) VALUES (${values.joinToString(", ")});"
         }
 
-        fun toInsertSqlForUketEvent(event: UketEvent): String {
+        private fun toInsertSqlForUketEvent(event: UketEvent): String {
             val tableName = "uket_event"
 
             val columns = mutableListOf<String>()
@@ -229,7 +315,7 @@ class UketEventRandomUtil {
             return "INSERT INTO $tableName (${columns.joinToString(", ")}) VALUES (${values.joinToString(", ")});"
         }
 
-        fun toSqlValue(value: Any?): String = when (value) {
+        private fun toSqlValue(value: Any?): String = when (value) {
             null -> "NULL"
             is String -> "'${value.replace("'", "''")}'"
             is Enum<*> -> "'${value.name}'"

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRepositoryTest.kt
@@ -94,157 +94,159 @@ class UketEventRepositoryTest(
     override fun extensions(): List<Extension> {
         return super.extensions() + listOf(SpringExtension) // SpringExtension 활성화
     }
-}
 
-private fun setDB5(entityManager: EntityManager): UketEvent {
-    val now = LocalDateTime.now()
+    companion object {
+        private fun setDB5(entityManager: EntityManager): UketEvent {
+            val now = LocalDateTime.now()
 
-    val uketEventRounds = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(3)))
-    val banners = listOf(
-        Banner(id = 0L, uketEvent = null, imageId = 1, link = "link1"),
-        Banner(id = 0L, uketEvent = null, imageId = 2, link = "link2"),
-        Banner(id = 0L, uketEvent = null, imageId = 3, link = "link3")
-    )
-    val uketEvent =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(2),
-            now.plusDays(2),
-            uketEventRounds,
-            banners
-        )
+            val uketEventRounds = UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(3)))
+            val banners = listOf(
+                Banner(id = 0L, uketEvent = null, imageId = 1, link = "link1"),
+                Banner(id = 0L, uketEvent = null, imageId = 2, link = "link2"),
+                Banner(id = 0L, uketEvent = null, imageId = 3, link = "link3")
+            )
+            val uketEvent =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(2),
+                    now.plusDays(2),
+                    uketEventRounds,
+                    banners
+                )
 
-    entityManager.persist(uketEvent)
-    entityManager.flush()
-    return uketEvent
-}
+            entityManager.persist(uketEvent)
+            entityManager.flush()
+            return uketEvent
+        }
 
-private fun setDB4(entityManager: EntityManager): UketEvent {
-    val now = LocalDateTime.now()
+        private fun setDB4(entityManager: EntityManager): UketEvent {
+            val now = LocalDateTime.now()
 
-    val uketEventRounds = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(3)))
-    val uketEvent =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(2),
-            now.plusDays(2),
-            uketEventRounds,
-            listOf()
-        )
+            val uketEventRounds = UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(3)))
+            val uketEvent =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(2),
+                    now.plusDays(2),
+                    uketEventRounds,
+                    listOf()
+                )
 
-    entityManager.persist(uketEvent)
-    entityManager.flush()
-    return uketEvent
-}
+            entityManager.persist(uketEvent)
+            entityManager.flush()
+            return uketEvent
+        }
 
-private fun setDB3(entityManager: EntityManager) {
-    val now = LocalDateTime.now()
+        private fun setDB3(entityManager: EntityManager) {
+            val now = LocalDateTime.now()
 
-    val uketEventRounds1 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(6), now.plusDays(7)))
-    val uketEvent1 =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(2),
-            now.plusDays(2),
-            uketEventRounds1,
-            listOf()
-        )
-    entityManager.persist(uketEvent1)
+            val uketEventRounds1 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(6), now.plusDays(7)))
+            val uketEvent1 =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(2),
+                    now.plusDays(2),
+                    uketEventRounds1,
+                    listOf()
+                )
+            entityManager.persist(uketEvent1)
 
-    val uketEventRounds2 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(8)))
-    val uketEvent2 =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(3),
-            now.plusDays(3),
-            uketEventRounds2,
-            listOf()
-        )
-    entityManager.persist(uketEvent2)
+            val uketEventRounds2 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(8)))
+            val uketEvent2 =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(3),
+                    now.plusDays(3),
+                    uketEventRounds2,
+                    listOf()
+                )
+            entityManager.persist(uketEvent2)
 
-    val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundWithDate(
-        listOf(now.minusDays(2), now.minusDays(1))
-    )
-    val closedEvent = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(4),
-        now.minusDays(3),
-        uketEventRounds3,
-        listOf()
-    )
-    entityManager.persist(closedEvent)
+            val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundsWithDate(
+                listOf(now.minusDays(2), now.minusDays(1))
+            )
+            val closedEvent = UketEventRandomUtil.createUketEvent(
+                now.minusDays(4),
+                now.minusDays(3),
+                uketEventRounds3,
+                listOf()
+            )
+            entityManager.persist(closedEvent)
 
-    entityManager.flush()
-}
+            entityManager.flush()
+        }
 
-private fun setDB2(entityManager: EntityManager) {
-    val now = LocalDateTime.now()
+        private fun setDB2(entityManager: EntityManager) {
+            val now = LocalDateTime.now()
 
-    val uketEventRounds1 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(3), now.plusDays(4)))
-    val uketEvent1 =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(2),
-            now.plusDays(2),
-            uketEventRounds1,
-            listOf()
-        )
-    entityManager.persist(uketEvent1)
+            val uketEventRounds1 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(3), now.plusDays(4)))
+            val uketEvent1 =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(2),
+                    now.plusDays(2),
+                    uketEventRounds1,
+                    listOf()
+                )
+            entityManager.persist(uketEvent1)
 
-    val uketEventRounds2 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(7), now.plusDays(8)))
-    val uketEvent2 =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(3),
-            now.plusDays(3),
-            uketEventRounds2,
-            listOf()
-        )
-    entityManager.persist(uketEvent2)
+            val uketEventRounds2 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(7), now.plusDays(8)))
+            val uketEvent2 =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(3),
+                    now.plusDays(3),
+                    uketEventRounds2,
+                    listOf()
+                )
+            entityManager.persist(uketEvent2)
 
-    val uketEventRounds3 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(5)))
-    val uketEvent3 =
-        UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-            now.minusDays(4),
-            now.plusDays(4),
-            uketEventRounds3,
-            listOf()
-        )
-    entityManager.persist(uketEvent3)
+            val uketEventRounds3 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(5)))
+            val uketEvent3 =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(4),
+                    now.plusDays(4),
+                    uketEventRounds3,
+                    listOf()
+                )
+            entityManager.persist(uketEvent3)
 
-    entityManager.flush()
-}
+            entityManager.flush()
+        }
 
-private fun setDB(entityManager: EntityManager): Long {
-    val organization = Organization(
-        name = "organizationA",
-        organizationImagePath = null,
-    )
-    entityManager.persist(organization)
+        private fun setDB(entityManager: EntityManager): Long {
+            val organization = Organization(
+                name = "organizationA",
+                organizationImagePath = null,
+            )
+            entityManager.persist(organization)
 
-    val uketEventRound = UketEventRound(
-        uketEvent = null,
-        eventRoundDateTime = LocalDateTime.now()
-    )
+            val uketEventRound = UketEventRound(
+                uketEvent = null,
+                eventRoundDateTime = LocalDateTime.now()
+            )
 
-    val uketEvent = UketEvent(
-        organizationId = organization.id,
-        eventName = "uketEventA",
-        eventType = EventType.FESTIVAL,
-        location = "locationA",
-        ticketPrice = 1000,
-        ticketingStartDateTime = LocalDateTime.now(),
-        ticketingEndDateTime = LocalDateTime.now(),
-        totalTicketCount = 0,
-        details = UketEvent.EventDetails(
-            "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
-        ),
-        eventImageId = "",
-        thumbnailImageId = "",
-        _uketEventRounds = listOf(uketEventRound),
-        _banners = listOf()
-    )
+            val uketEvent = UketEvent(
+                organizationId = organization.id,
+                eventName = "uketEventA",
+                eventType = EventType.FESTIVAL,
+                location = "locationA",
+                ticketPrice = 1000,
+                ticketingStartDateTime = LocalDateTime.now(),
+                ticketingEndDateTime = LocalDateTime.now(),
+                totalTicketCount = 0,
+                details = UketEvent.EventDetails(
+                    "", "", UketEvent.EventContact(UketEvent.EventContact.ContactType.INSTAGRAM, "")
+                ),
+                eventImageId = "",
+                thumbnailImageId = "",
+                _uketEventRounds = listOf(uketEventRound),
+                _banners = listOf()
+            )
 
-    entityManager.persist(uketEvent)
-    entityManager.flush()
+            entityManager.persist(uketEvent)
+            entityManager.flush()
 
-    return uketEvent.id
+            return uketEvent.id
+        }
+    }
 }

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRoundRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRoundRepositoryTest.kt
@@ -1,0 +1,65 @@
+package uket.domain.uketEvent
+
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.date.after
+import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import uket.domain.uketevent.repository.UketEventRoundRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@DataJpaTest
+class UketEventRoundRepositoryTest(
+    private val uketEventRoundRepository: UketEventRoundRepository,
+    private val entityManager: EntityManager,
+) : DescribeSpec({
+
+        isolationMode = IsolationMode.InstancePerTest
+
+        describe("findByUketEventIdAAndEventRoundDateAfterNow") {
+            context("회차가 2개 있고, 하나는 어제일 때") {
+                it("1개의 회차 조회") {
+                    val now = LocalDateTime.now()
+                    val uketEventId = setDB(entityManager, now)
+                    val uketEventRounds = uketEventRoundRepository.findByUketEventIdAAndEventRoundDateAfter(
+                        uketEventId,
+                        now.truncatedTo(
+                            ChronoUnit.DAYS
+                        )
+                    )
+                    uketEventRounds.size shouldBe 1
+                    uketEventRounds[0].eventRoundDateTime.toLocalDate() shouldBe after(LocalDate.now().minusDays(1))
+                }
+            }
+        }
+    }
+    ) {
+    override fun extensions(): List<Extension> {
+        return super.extensions() + listOf(SpringExtension) // SpringExtension 활성화
+    }
+
+    companion object {
+        private fun setDB(entityManager: EntityManager, now: LocalDateTime): Long {
+            val uketEventRounds =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.minusDays(1), now))
+
+            val uketEvent =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(3),
+                    now.minusDays(2),
+                    uketEventRounds,
+                    listOf()
+                )
+
+            entityManager.persist(uketEvent)
+            entityManager.flush()
+
+            return uketEvent.id
+        }
+    }
+}

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventRoundServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventRoundServiceTest.kt
@@ -1,0 +1,67 @@
+package uket.domain.uketEvent
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import uket.domain.uketevent.entity.UketEventRound
+import uket.domain.uketevent.repository.UketEventRoundRepository
+import uket.domain.uketevent.service.UketEventRoundService
+import java.time.LocalDateTime
+
+class UketEventRoundServiceTest :
+    DescribeSpec({
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val uketEventRoundRepository: UketEventRoundRepository = mockk<UketEventRoundRepository>()
+        val uketEventRoundService: UketEventRoundService = UketEventRoundService(uketEventRoundRepository)
+
+        describe("findByUketEventIdAndDateAfter") {
+            context("회차가 어제 오후, 오늘 오전, 내일 오후 3가지가 있을 때") {
+                it("오늘 날짜 이후로 조회") {
+                    val (eventId, uketEventRounds) = setDB()
+                    every {
+                        uketEventRoundRepository.findByUketEventIdAAndEventRoundDateAfter(
+                            eventId,
+                            LocalDateTime
+                                .now()
+                                .withHour(0)
+                                .withMinute(0)
+                                .withSecond(0)
+                                .withNano(0)
+                        )
+                    } returns uketEventRounds
+
+                    val findRounds = uketEventRoundService.findByUketEventIdAndDateAfter(eventId, LocalDateTime.now())
+                    findRounds.size shouldBe 2
+                }
+            }
+        }
+    }) {
+    companion object {
+        private fun setDB(): Pair<Long, List<UketEventRound>> {
+            val now = LocalDateTime.now()
+
+            val uketEventRounds =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(
+                    listOf(
+                        now.minusDays(1).withHour(20),
+                        now.withHour(8),
+                        now.plusDays(1).withHour(20)
+                    )
+                )
+
+            val uketEvent =
+                UketEventRandomUtil.createUketEvent(
+                    now.minusDays(3),
+                    now.minusDays(2),
+                    uketEventRounds,
+                    listOf()
+                )
+
+            return Pair(uketEvent.id, listOf(uketEventRounds[1], uketEventRounds[2]))
+        }
+    }
+}

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventServiceTest.kt
@@ -20,7 +20,7 @@ class UketEventServiceTest :
 
         describe("유효한 행사 목록 조회") {
             context("티켓팅 진행 중인 행사 3개가 있을 때") {
-                val (uketEvent1, uketEvent2, uketEvent3) = setDB(uketEventRepository)
+                val (uketEvent1, uketEvent2, uketEvent3) = setDB()
                 every { uketEventRepository.findAllByEventEndDateAfterNowWithUketEventRound() } returns listOf(
                     uketEvent1,
                     uketEvent2,
@@ -38,7 +38,7 @@ class UketEventServiceTest :
             context("티켓팅 진행 중인 행사 2개, 티켓팅 시작 전인 행사 1개, 티켓팅 종료된 행사 1개가 있을 때") {
                 val now = LocalDateTime.now()
                 val (uketEvent1, uketEvent2) = setDB2(now)
-                val (notOpenedEvent, closedEvent) = setDB3(now, uketEvent2)
+                val (notOpenedEvent, closedEvent) = setDB3(now)
 
                 every { uketEventRepository.findAllByEventEndDateAfterNowWithUketEventRound() } returns listOf(
                     uketEvent1,
@@ -61,75 +61,81 @@ class UketEventServiceTest :
         it("더미데이터 출력") {
             UketEventRandomUtil.createDummyData()
         }
-    })
+    }) {
+    companion object {
+        private fun setDB3(
+            now: LocalDateTime,
+        ): Pair<UketEvent, UketEvent> {
+            val uketEventRounds3 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(7), now.plusDays(8)))
+            val notOpenedEvent = UketEventRandomUtil.createUketEvent(
+                now.plusDays(3),
+                now.plusDays(5),
+                uketEventRounds3,
+                listOf()
+            )
 
-private fun setDB3(
-    now: LocalDateTime,
-    uketEvent2: UketEvent,
-): Pair<UketEvent, UketEvent> {
-    val uketEventRounds3 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(7), now.plusDays(8)))
-    val notOpenedEvent = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.plusDays(3),
-        now.plusDays(5),
-        uketEventRounds3,
-        listOf()
-    )
+            val uketEventRounds4 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.minusDays(2), now.plusDays(1)))
+            val closedEvent = UketEventRandomUtil.createUketEvent(
+                now.minusDays(4),
+                now.minusDays(3),
+                uketEventRounds4,
+                listOf()
+            )
+            return Pair(notOpenedEvent, closedEvent)
+        }
 
-    val uketEventRounds4 =
-        UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.minusDays(2), now.plusDays(1)))
-    val closedEvent = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(4),
-        now.minusDays(3),
-        uketEventRounds4,
-        listOf()
-    )
-    return Pair(notOpenedEvent, closedEvent)
-}
+        private fun setDB2(now: LocalDateTime): Pair<UketEvent, UketEvent> {
+            val uketEventRounds1 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(5), now.plusDays(6)))
+            val uketEvent1 = UketEventRandomUtil.createUketEvent(
+                now.minusDays(2),
+                now.plusDays(2),
+                uketEventRounds1,
+                listOf()
+            )
 
-private fun setDB2(now: LocalDateTime): Pair<UketEvent, UketEvent> {
-    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(5), now.plusDays(6)))
-    val uketEvent1 = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(2),
-        now.plusDays(2),
-        uketEventRounds1,
-        listOf()
-    )
+            val uketEventRounds2 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(7), now.plusDays(8)))
+            val uketEvent2 = UketEventRandomUtil.createUketEvent(
+                now.minusDays(3),
+                now.plusDays(3),
+                uketEventRounds2,
+                listOf()
+            )
+            return Pair(uketEvent1, uketEvent2)
+        }
 
-    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(7), now.plusDays(8)))
-    val uketEvent2 = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(3),
-        now.plusDays(3),
-        uketEventRounds2,
-        listOf()
-    )
-    return Pair(uketEvent1, uketEvent2)
-}
+        private fun setDB(): Triple<UketEvent, UketEvent, UketEvent> {
+            val now = LocalDateTime.now()
+            val uketEventRounds1 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(7), now.plusDays(8)))
+            val uketEvent1 = UketEventRandomUtil.createUketEvent(
+                now.minusDays(2),
+                now.plusDays(2),
+                uketEventRounds1,
+                listOf()
+            )
 
-private fun setDB(uketEventRepository: UketEventRepository): Triple<UketEvent, UketEvent, UketEvent> {
-    val now = LocalDateTime.now()
-    val uketEventRounds1 = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(7), now.plusDays(8)))
-    val uketEvent1 = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(2),
-        now.plusDays(2),
-        uketEventRounds1,
-        listOf()
-    )
+            val uketEventRounds2 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(9), now.plusDays(10)))
+            val uketEvent2 = UketEventRandomUtil.createUketEvent(
+                now.minusDays(3),
+                now.plusDays(3),
+                uketEventRounds2,
+                listOf()
+            )
 
-    val uketEventRounds2 = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(9), now.plusDays(10)))
-    val uketEvent2 = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(3),
-        now.plusDays(3),
-        uketEventRounds2,
-        listOf()
-    )
-
-    val uketEventRounds3 = UketEventRandomUtil.createUketEventsRoundWithDate(listOf(now.plusDays(5), now.plusDays(6)))
-    val uketEvent3 = UketEventRandomUtil.createUketEventWithDatesAndEventRoundsAndBanners(
-        now.minusDays(4),
-        now.plusDays(4),
-        uketEventRounds3,
-        listOf()
-    )
-    return Triple(uketEvent1, uketEvent2, uketEvent3)
+            val uketEventRounds3 =
+                UketEventRandomUtil.createUketEventsRoundsWithDate(listOf(now.plusDays(5), now.plusDays(6)))
+            val uketEvent3 = UketEventRandomUtil.createUketEvent(
+                now.minusDays(4),
+                now.plusDays(4),
+                uketEventRounds3,
+                listOf()
+            )
+            return Triple(uketEvent1, uketEvent2, uketEvent3)
+        }
+    }
 }


### PR DESCRIPTION
# 📌 개요
- 회차/그룹 조회 API migration 작업을 진행했습니다.

# 💻 작업사항
- [x] 회차/그룹 조회 API 작성
- [x] 테스트 작성
<details>
<summary>포스트맨 테스트</summary>
행사 조회 시<br>
<img src="https://github.com/user-attachments/assets/67e27b1c-37c0-4a75-a06d-fa94fbab1dd5">
티켓팅 진행 중인 행사의 회차 조회 시<br>
<img src="https://github.com/user-attachments/assets/b37d0fbc-2c00-4ea9-9032-0dd8f6f791ff">
티켓팅 예정, 종료된 행사의 회차 조회 시<br>
<img src="https://github.com/user-attachments/assets/8d7fb2dd-d86e-41b1-9489-3b1fa7fed4fd">
입장 그룹 조회 시<br>
<img src="https://github.com/user-attachments/assets/b369436c-1c17-44d7-9593-a095b3610dc8">
</details>

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 회차 별로 그룹을 조회하도록 구성해두었는데, 회차+그룹을 한번에 조회하는 형태가 더 좋다고 생각하시는지 궁금합니다
