### PR TITLE
fix : 티켓팅 상태 -> 날짜 2단계의 정렬 기준이 반영되지 않았던 점 수정

### DIFF
--- a/src/main/kotlin/uket/facade/UketEventFacade.kt
+++ b/src/main/kotlin/uket/facade/UketEventFacade.kt
@@ -56,9 +56,11 @@ class UketEventFacade(
         val orderedList = eventItemList
             .sortedWith(
                 ticketingStatusComparator()
-            ).sortedBy {
-                it.eventStartDate
-            }
+                    .thenBy {
+                        it.eventStartDate
+                    }
+            )
+
         return orderedList
     }
 


### PR DESCRIPTION
# 📌 개요
- 행사 목록 조회 시, 정렬을 2단계로 나눠 적용되지 않았던 부분 수정했습니다.

# 💻 작업사항
- [x] 작업 내용

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
