### PR TITLE
[UKET-165] 이미지 아이디를 경로로 변환하는 Aspect 추가

### DIFF
--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uket.api.user.request.EventListQueryType
-import uket.api.user.response.ActiveEventsResponse
 import uket.api.user.response.EntryGroupListItemResponse
 import uket.api.user.response.EventDetailResponse
 import uket.api.user.response.EventRoundListItemResponse
@@ -16,6 +15,7 @@ import uket.api.user.response.ReservationInfoResponse
 import uket.common.response.ListResponse
 import uket.domain.admin.service.OrganizationService
 import uket.domain.payment.service.PaymentService
+import uket.domain.uketevent.dto.EventListItem
 import uket.domain.uketevent.service.UketEventRoundService
 import uket.domain.uketevent.service.UketEventService
 import uket.facade.UketEventFacade
@@ -34,10 +34,10 @@ class EventController(
     @GetMapping("/uket-events")
     fun getEvents(
         @RequestParam("type") type: EventListQueryType,
-    ): ResponseEntity<ActiveEventsResponse> {
+    ): ResponseEntity<ListResponse<EventListItem>> {
         val now = LocalDateTime.now()
         val itemList = uketEventFacade.getNowActiveEventItemList(type.name, now)
-        return ResponseEntity.ok(ActiveEventsResponse(itemList))
+        return ResponseEntity.ok(ListResponse(itemList))
     }
 
     @Operation(summary = "행사 상세 정보 조회", description = "누구나 조회 가능한 행사의 상세 정보를 가져옵니다")

--- a/src/main/kotlin/uket/api/user/response/EventDetailResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/EventDetailResponse.kt
@@ -1,5 +1,6 @@
 package uket.api.user.response
 
+import uket.common.aop.imageUrl.ImagePath
 import uket.common.enums.EventType
 import uket.domain.admin.entity.Organization
 import uket.domain.uketevent.entity.Banner
@@ -13,7 +14,7 @@ data class EventDetailResponse(
     val firstRoundStartDateTime: LocalDateTime,
     val lastRoundStartDateTime: LocalDateTime,
     val information: String,
-    val detailImagePath: String,
+    @ImagePath val detailImagePath: String,
     val banners: List<EventDetailBannerDto>,
     val caution: String,
     val organizationName: String,
@@ -21,12 +22,12 @@ data class EventDetailResponse(
     val location: String,
 ) {
     data class EventDetailBannerDto(
-        val imageId: Long,
+        @ImagePath val imagePath: Long,
         val link: String,
     ) {
         companion object {
             fun from(banner: Banner): EventDetailBannerDto = EventDetailBannerDto(
-                imageId = banner.imageId,
+                imagePath = banner.imageId,
                 link = banner.link
             )
         }

--- a/src/main/kotlin/uket/common/aop/imageUrl/ImagePath.kt
+++ b/src/main/kotlin/uket/common/aop/imageUrl/ImagePath.kt
@@ -1,0 +1,5 @@
+package uket.common.aop.imageUrl
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ImagePath

--- a/src/main/kotlin/uket/common/aop/imageUrl/ImagePathAspect.kt
+++ b/src/main/kotlin/uket/common/aop/imageUrl/ImagePathAspect.kt
@@ -11,11 +11,8 @@ import uket.common.response.ListResponse
 @Aspect
 @Component
 class ImagePathAspect {
-    @Value("\${spring.cloud.aws.s3.bucket}")
-    lateinit var bucketName: String
-
-    @Value("\${spring.cloud.aws.s3.region}")
-    lateinit var region: String
+    @Value("\${app.s3.deploy-url}")
+    lateinit var deployPath: String
 
     @Around("execution(* uket.api..*Controller.*(..))")
     fun imageUrlReturnValue(joinPoint: ProceedingJoinPoint): Any? {
@@ -40,7 +37,7 @@ class ImagePathAspect {
             if (prop.isAnnotationPresent(ImagePath::class.java)) {
                 prop.isAccessible = true
                 val value = prop.get(body)
-                prop.set(body, "https://$bucketName.s3.$region/images/$value")
+                prop.set(body, "$deployPath$value")
             }
         }
     }

--- a/src/main/kotlin/uket/common/aop/imageUrl/ImagePathAspect.kt
+++ b/src/main/kotlin/uket/common/aop/imageUrl/ImagePathAspect.kt
@@ -1,0 +1,47 @@
+package uket.common.aop.imageUrl
+
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import uket.common.response.ListResponse
+
+@Aspect
+@Component
+class ImagePathAspect {
+    @Value("\${spring.cloud.aws.s3.bucket}")
+    lateinit var bucketName: String
+
+    @Value("\${spring.cloud.aws.s3.region}")
+    lateinit var region: String
+
+    @Around("execution(* uket.api..*Controller.*(..))")
+    fun imageUrlReturnValue(joinPoint: ProceedingJoinPoint): Any? {
+        val result = joinPoint.proceed()
+
+        if (result is ResponseEntity<*> && result.body != null) {
+            val body = result.body!!
+
+            when (body) {
+                is ListResponse<*> -> {
+                    body.items.forEach { changeImageIdToUrl(it!!) }
+                }
+                else -> changeImageIdToUrl(body)
+            }
+        }
+
+        return result
+    }
+
+    private fun changeImageIdToUrl(body: Any) {
+        body::class.java.declaredFields.forEach { prop ->
+            if (prop.isAnnotationPresent(ImagePath::class.java)) {
+                prop.isAccessible = true
+                val value = prop.get(body)
+                prop.set(body, "https://$bucketName.s3.$region/images/$value")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/uket/domain/uketevent/dto/EventListItem.kt
+++ b/src/main/kotlin/uket/domain/uketevent/dto/EventListItem.kt
@@ -1,5 +1,6 @@
 package uket.domain.uketevent.dto
 
+import uket.common.aop.imageUrl.ImagePath
 import uket.domain.uketevent.entity.UketEvent
 import uket.domain.uketevent.entity.UketEventRound
 import uket.domain.uketevent.enums.TicketingStatus
@@ -8,7 +9,7 @@ import java.time.LocalDateTime
 data class EventListItem(
     val eventId: Long,
     val eventName: String,
-    val eventThumbnailImagePath: String,
+    @ImagePath val eventThumbnailImagePath: String,
     val eventStartDate: LocalDateTime,
     val eventEndDate: LocalDateTime,
     val ticketingStartDate: LocalDateTime,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,6 +26,7 @@ spring:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}
         bucket: ${AWS_S3_BUCKET}
+        region: ${AWS_S3_REGION}
   mail:
     host: smtp.gmail.com
     port: 587

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,7 +26,7 @@ spring:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}
         bucket: ${AWS_S3_BUCKET}
-        region: ${AWS_S3_REGION}
+
   mail:
     host: smtp.gmail.com
     port: 587
@@ -76,3 +76,5 @@ app:
     width: 300
     height: 300
     type: png
+  s3:
+    deploy-url: ${S3_DEPLOY_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,6 +49,7 @@ spring:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}
         bucket: ${AWS_S3_BUCKET}
+        region: ${AWS_S3_REGION}
 
 app:
   token:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -49,7 +49,6 @@ spring:
         access-key: ${AWS_S3_ACCESS_KEY}
         secret-key: ${AWS_S3_SECRET_KEY}
         bucket: ${AWS_S3_BUCKET}
-        region: ${AWS_S3_REGION}
 
 app:
   token:
@@ -76,3 +75,5 @@ app:
     width: 300
     height: 300
     type: png
+  s3:
+    deploy-url: ${S3_DEPLOY_URL}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -62,6 +62,8 @@ app:
     width: 300
     height: 300
     type: png
+  s3:
+    deploy-url: "test.url"
 
 logging:
   level:


### PR DESCRIPTION
# 📌 개요
- @ImageUrl 어노테이션과 함께 이미지 경로를 구성해주는 Aspect를 추가했습니다.

# 💻 작업사항
- [x] ImageUrl, ImageUrlAspect 추가 및 적용

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 프론트에 이미지를 넘겨줄 때 경로를 넘겨주게 되는 경우, 
매번 배포 경로를 앞에 붙여줘야하는 번거로움이 있는 것 같아 Aspect를 추가했습니다.
util 클래스냐 Aspect냐 고민하다가 선택한 부분인데, 더 좋은 방법이나 util이 낫다고 생각하시면 의견 부탁드립니당
\+ 예전에 톡방에서 언급했던 내용인데, 경로가 아니라 아이디만 넘겨주는 형태로 생각 중이신가요?
