### PR TITLE
[UKET-171] 예매 정보 조회 시, 매진 시간대도 제공

### DIFF
--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -80,7 +80,7 @@ class EventController(
         @PathVariable("id") eventId: Long,
     ): ResponseEntity<ReservationInfoResponse> {
         val now = LocalDateTime.now()
-        val entryGroupMap = uketEventFacade.findValidEntryGroupMap(eventId, now)
+        val entryGroupMap = uketEventFacade.getValidEntryGroupMap(eventId, now)
         val roundResponses = entryGroupMap.keys.map { round ->
             val groups = entryGroupMap.get(round)
             val groupResponses = groups!!.map {

--- a/src/main/kotlin/uket/domain/uketevent/repository/EntryGroupRepository.kt
+++ b/src/main/kotlin/uket/domain/uketevent/repository/EntryGroupRepository.kt
@@ -21,7 +21,6 @@ interface EntryGroupRepository : JpaRepository<EntryGroup, Long> {
             JOIN FETCH eg.uketEventRound uer
             WHERE uer.id IN :uketEventRoundIds
             AND eg.entryStartDateTime >= :at
-            AND eg.ticketCount < eg.totalTicketCount
         """
     )
     fun findByUketEventIdAndStartDateTimeAfterWithUketEventRound(uketEventRoundIds: List<Long>, at: LocalDateTime): List<EntryGroup>

--- a/src/main/kotlin/uket/facade/UketEventFacade.kt
+++ b/src/main/kotlin/uket/facade/UketEventFacade.kt
@@ -27,7 +27,7 @@ class UketEventFacade(
     }
 
     @Transactional(readOnly = true)
-    fun findValidEntryGroupMap(eventId: Long, at: LocalDateTime): Map<UketEventRound, List<EntryGroup>> {
+    fun getValidEntryGroupMap(eventId: Long, at: LocalDateTime): Map<UketEventRound, List<EntryGroup>> {
         val uketEventRounds = uketEventRoundService.getNowTicketingRounds(eventId, at)
         val uketEventRoundIds = uketEventRounds.map { it.id }
 


### PR DESCRIPTION
# 📌 개요
- 기존 예매 정보에는 매진된 시간대는 아예 목록으로 제공하지 않았었는데, 매진 여부를 표시하기 위해 추가했습니다
![image](https://github.com/user-attachments/assets/e670cb44-b9ea-4cfd-b72b-bcd9d1570565)


# 💻 작업사항
- [x] entryGroup 쿼리 시 ticketCount 조건문 제거
테스트 결과
![image](https://github.com/user-attachments/assets/d444a4aa-ce75-46cd-893d-9bb725fc5aac)

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
