### PR TITLE
[UKET-180] 내 행사 조회 시 계정 구분없이 조회되던 내용 수정 구현

### DIFF
--- a/src/main/kotlin/uket/api/admin/EventRegistrationController.kt
+++ b/src/main/kotlin/uket/api/admin/EventRegistrationController.kt
@@ -101,10 +101,12 @@ class EventRegistrationController(
     fun getUketEventRegistrations(
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
+        @LoginAdminId adminId: Long,
     ): CustomPageResponse<UketEventRegistrationSummaryResponse> {
         val pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        val admin = adminService.getByIdWithOrganization(adminId)
 
-        val uketEventRegistrationSummaryResponse = eventRegistrationService.findAll(pageRequest).map {
+        val uketEventRegistrationSummaryResponse = eventRegistrationService.findAllByOrganizationId(pageRequest, admin.organization.id).map {
             UketEventRegistrationSummaryResponse.from(it)
         }
         return CustomPageResponse(uketEventRegistrationSummaryResponse)

--- a/src/main/kotlin/uket/api/admin/EventRegistrationController.kt
+++ b/src/main/kotlin/uket/api/admin/EventRegistrationController.kt
@@ -106,7 +106,7 @@ class EventRegistrationController(
         val pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         val admin = adminService.getByIdWithOrganization(adminId)
 
-        val uketEventRegistrationSummaryResponse = eventRegistrationService.findAllByOrganizationId(pageRequest, admin.organization.id).map {
+        val uketEventRegistrationSummaryResponse = eventRegistrationService.findAllByOrganizationId(admin.organization.id, pageRequest).map {
             UketEventRegistrationSummaryResponse.from(it)
         }
         return CustomPageResponse(uketEventRegistrationSummaryResponse)

--- a/src/main/kotlin/uket/domain/admin/service/AdminService.kt
+++ b/src/main/kotlin/uket/domain/admin/service/AdminService.kt
@@ -1,5 +1,6 @@
 package uket.domain.admin.service
 
+import org.hibernate.Hibernate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
@@ -20,6 +21,14 @@ class AdminService(
     fun getById(adminId: Long): Admin {
         val admin = adminRepository.findByIdOrNull(adminId)
             ?: throw IllegalStateException("해당 어드민을 찾을 수 없습니다")
+        return admin
+    }
+
+    @Transactional(readOnly = true)
+    fun getByIdWithOrganization(adminId: Long): Admin {
+        val admin = adminRepository.findByIdOrNull(adminId)
+            ?: throw IllegalStateException("해당 어드민을 찾을 수 없습니다")
+        Hibernate.initialize(admin.organization)
         return admin
     }
 

--- a/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationRepository.kt
+++ b/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uket.domain.eventregistration.entity.EventRegistration
 
 interface EventRegistrationRepository : JpaRepository<EventRegistration, Long> {
-    fun findAllByOrganizationId(pageable: Pageable, organizationId: Long): Page<EventRegistration>
+    fun findAllByOrganizationId(organizationId: Long, pageable: Pageable): Page<EventRegistration>
 }

--- a/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationRepository.kt
+++ b/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationRepository.kt
@@ -1,6 +1,10 @@
 package uket.domain.eventregistration.service
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import uket.domain.eventregistration.entity.EventRegistration
 
-interface EventRegistrationRepository : JpaRepository<EventRegistration, Long>
+interface EventRegistrationRepository : JpaRepository<EventRegistration, Long> {
+    fun findAllByOrganizationId(pageable: Pageable, organizationId: Long): Page<EventRegistration>
+}

--- a/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
+++ b/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
@@ -24,8 +24,8 @@ class EventRegistrationService(
         ?: throw IllegalArgumentException("[EventRegistrationService] EventRegistration을 조회할 수 없습니다. | eventRegistrationId: $id")
 
     @Transactional(readOnly = true)
-    fun findAll(pageable: Pageable): Page<EventRegistration> {
-        return eventRegistrationRepository.findAll(pageable)
+    fun findAllByOrganizationId(pageable: Pageable, organizationId: Long): Page<EventRegistration> {
+        return eventRegistrationRepository.findAllByOrganizationId(pageable, organizationId)
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
+++ b/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
@@ -24,8 +24,8 @@ class EventRegistrationService(
         ?: throw IllegalArgumentException("[EventRegistrationService] EventRegistration을 조회할 수 없습니다. | eventRegistrationId: $id")
 
     @Transactional(readOnly = true)
-    fun findAllByOrganizationId(pageable: Pageable, organizationId: Long): Page<EventRegistration> {
-        return eventRegistrationRepository.findAllByOrganizationId(pageable, organizationId)
+    fun findAllByOrganizationId(organizationId: Long, pageable: Pageable): Page<EventRegistration> {
+        return eventRegistrationRepository.findAllByOrganizationId(organizationId, pageable)
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
# 📌 개요
- 내 행사 조회시에 계정 구분없이 조회되던 내용을 수정 구현했습니다.

# 💻 작업사항
- [x] AdminId 기반으로 organization별로 구분해서 행사 보여주도록 수정 구현

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
