### PR TITLE
hotfix: image 조회 jwt 필터 삭제

### DIFF
--- a/src/main/kotlin/uket/api/common/ImageController.kt
+++ b/src/main/kotlin/uket/api/common/ImageController.kt
@@ -1,7 +1,6 @@
 package uket.api.common
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -18,7 +17,6 @@ class ImageController(
     private val s3ImageFacade: S3ImageFacade,
     private val s3Service: S3Service,
 ) {
-    @SecurityRequirement(name = "JWT")
     @Operation(summary = "이미지 조회", description = "이미지 id를 이용해 해당 image를 서버로부터 넘겨받습니다.")
     @GetMapping("/image/{imageId}")
     fun getImage(

--- a/src/main/kotlin/uket/auth/config/AuthConfig.kt
+++ b/src/main/kotlin/uket/auth/config/AuthConfig.kt
@@ -31,6 +31,7 @@ class AuthConfig(
             .excludePathPatterns("/uket-events/**")
             .excludePathPatterns("/users/register")
             .excludePathPatterns("/terms/**")
+            .excludePathPatterns("/image/*")
     }
 
     override fun addResourceHandlers(registry: ResourceHandlerRegistry) {

--- a/src/main/kotlin/uket/auth/config/SecurityConfig.kt
+++ b/src/main/kotlin/uket/auth/config/SecurityConfig.kt
@@ -91,6 +91,10 @@ class SecurityConfig(
                     .permitAll()
             }.authorizeHttpRequests { registry ->
                 registry
+                    .requestMatchers("/image/*")
+                    .permitAll()
+            }.authorizeHttpRequests { registry ->
+                registry
                     .requestMatchers("/admin/users/login")
                     .permitAll()
                     .requestMatchers("/auth/**")


### PR DESCRIPTION
# 📌 개요
- 이미지 조회 시 로그인하지않아도 조회가 가능해야해 jwt filter를 삭제했습니다.

# 💻 작업사항
- [x] 이미지 조회 jwt 필터 삭제

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
