### PR TITLE
[UKET-197] 마케팅 정보 수신 동의 조회/수정 기능 추가

### DIFF
--- a/src/main/kotlin/uket/api/user/TermsController.kt
+++ b/src/main/kotlin/uket/api/user/TermsController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import uket.api.user.request.TermsAgreeRequest
+import uket.api.user.response.OptionalTermAnswerResponse
 import uket.api.user.response.TermsAgreeResponse
 import uket.api.user.response.TermsResponse
 import uket.auth.config.userId.LoginUserId
@@ -16,11 +17,13 @@ import uket.common.response.ListResponse
 import uket.domain.terms.dto.TermsAgreeAnswer
 import uket.domain.terms.entity.TermSign
 import uket.facade.TermsDocumentFacade
+import uket.facade.TermsTermSignFacade
 
 @Tag(name = "약관 관련 API", description = "약관 관련 API 입니다")
 @RestController
 class TermsController(
     private val termsDocumentFacade: TermsDocumentFacade,
+    private val termsTermSignFacade: TermsTermSignFacade,
 ) {
     @Operation(summary = "유저 확인 필요 약관 목록 제공", description = "유저가 확인해야하는 약관 목록을 제공합니다")
     @GetMapping("/terms/check-required")
@@ -31,6 +34,18 @@ class TermsController(
     ): ResponseEntity<ListResponse<TermsResponse>> {
         val checkRequireTerms = termsDocumentFacade.getAllActiveAndCheckRequiredByUser(userId)
         val responses = checkRequireTerms.map { TermsResponse.of(it) }
+        return ResponseEntity.ok(ListResponse(responses))
+    }
+
+    @Operation(summary = "유저 선택 약관 동의 여부 조회", description = "유저의 선택 약관에 대한 동의 여부를 조회합니다")
+    @GetMapping("/terms/optional-answer")
+    fun getOptionalTermAnswers(
+        @LoginUserId
+        @Parameter(hidden = true)
+        userId: Long,
+    ): ResponseEntity<ListResponse<OptionalTermAnswerResponse>> {
+        val optionalTermAnswers = termsTermSignFacade.getAllActiveAndOptionalUserAnswers(userId)
+        val responses = optionalTermAnswers.map { OptionalTermAnswerResponse.of(it) }
         return ResponseEntity.ok(ListResponse(responses))
     }
 

--- a/src/main/kotlin/uket/api/user/response/OptionalTermAnswerResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/OptionalTermAnswerResponse.kt
@@ -1,0 +1,19 @@
+package uket.api.user.response
+
+import uket.domain.terms.dto.OptionalTermAnswer
+
+data class OptionalTermAnswerResponse(
+    val termsId: Long,
+    val name: String,
+    val documentId: Long,
+    val isAgreed: Boolean,
+) {
+    companion object {
+        fun of(answer: OptionalTermAnswer): OptionalTermAnswerResponse = OptionalTermAnswerResponse(
+            termsId = answer.termsId,
+            name = answer.name,
+            documentId = answer.documentId,
+            isAgreed = answer.isAgreed
+        )
+    }
+}

--- a/src/main/kotlin/uket/domain/terms/dto/OptionalTermAnswer.kt
+++ b/src/main/kotlin/uket/domain/terms/dto/OptionalTermAnswer.kt
@@ -1,0 +1,20 @@
+package uket.domain.terms.dto
+
+import uket.domain.terms.entity.TermSign
+import uket.domain.terms.entity.Terms
+
+data class OptionalTermAnswer(
+    val termsId: Long,
+    val name: String,
+    val documentId: Long,
+    val isAgreed: Boolean,
+) {
+    companion object {
+        fun of(terms: Terms, termSign: TermSign): OptionalTermAnswer = OptionalTermAnswer(
+            termsId = terms.id,
+            name = terms.name,
+            documentId = termSign.document.id,
+            isAgreed = termSign.isAgreed
+        )
+    }
+}

--- a/src/main/kotlin/uket/domain/terms/entity/Terms.kt
+++ b/src/main/kotlin/uket/domain/terms/entity/Terms.kt
@@ -21,7 +21,7 @@ class Terms(
     @Enumerated(EnumType.STRING)
     val termsType: TermsType,
     val documentNo: Long,
-    val isActive: Boolean,
+    var isActive: Boolean,
 ) : BaseTimeEntity() {
     fun checkMandatory(isAgreed: Boolean) {
         if (termsType !== TermsType.MANDATORY) {

--- a/src/main/kotlin/uket/domain/terms/service/TermsService.kt
+++ b/src/main/kotlin/uket/domain/terms/service/TermsService.kt
@@ -4,6 +4,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uket.domain.terms.entity.Terms
+import uket.domain.terms.enums.TermsType
 import uket.domain.terms.repository.TermsRepository
 
 @Service
@@ -19,6 +20,12 @@ class TermsService(
 
     @Transactional(readOnly = true)
     fun findAllActive(): List<Terms> = termsRepository.findAllByIsActiveTrue()
+
+    @Transactional(readOnly = true)
+    fun findAllActiveOptional(): List<Terms> {
+        val activeTerms = termsRepository.findAllByIsActiveTrue()
+        return activeTerms.filter { it.termsType == TermsType.OPTIONAL }
+    }
 
     @Transactional(readOnly = true)
     fun findAllByIdIn(termIds: List<Long>): List<Terms> = termsRepository.findAllByIdIn(termIds)

--- a/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 @Table(
     name = "uket_event",
     indexes = [
-        Index(name = "index_uket_event_01", columnList = "uketEventId"),
+        Index(name = "index_uket_event_01", columnList = "id"),
         Index(name = "index_uket_event_02", columnList = "organizationId"),
     ]
 )

--- a/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
@@ -20,8 +20,7 @@ import java.time.LocalDateTime
 @Table(
     name = "uket_event",
     indexes = [
-        Index(name = "index_uket_event_01", columnList = "id"),
-        Index(name = "index_uket_event_02", columnList = "organizationId"),
+        Index(name = "index_uket_event_01", columnList = "organizationId")
     ]
 )
 class UketEvent(

--- a/src/main/kotlin/uket/facade/TermsTermSignFacade.kt
+++ b/src/main/kotlin/uket/facade/TermsTermSignFacade.kt
@@ -1,0 +1,22 @@
+package uket.facade
+
+import org.springframework.stereotype.Service
+import uket.domain.terms.dto.OptionalTermAnswer
+import uket.domain.terms.service.TermSignService
+import uket.domain.terms.service.TermsService
+
+@Service
+class TermsTermSignFacade(
+    private val termsService: TermsService,
+    private val termSignService: TermSignService,
+) {
+    fun getAllActiveAndOptionalUserAnswers(userId: Long): List<OptionalTermAnswer> {
+        val optionalTerms = termsService.findAllActiveOptional()
+        val termSignMap = termSignService.getLatestTermSignMap(optionalTerms, userId)
+
+        return optionalTerms.map { terms ->
+            val termSign = termSignMap[terms.id]!!
+            OptionalTermAnswer.of(terms, termSign)
+        }
+    }
+}


### PR DESCRIPTION
# 📌 개요
- 유저의 마케팅 정보 수신 동의 여부 조회/수정 기능을 추가했습니다.

# 💻 작업사항
- 최초에 유저에 필드를 추가해서 진행하려고 했었는데, 마케팅 정보 수신 동의 여부 자체가 "Terms" 도메인에 있음을 확인했습니다 => redunduncy
- 마케팅 정보 수신 동의 여부 뿐 아니라 OPTIONAL한 Term에 대해서는 모두 유저 정보에서 조회/수정 기능이 필요할 것이라고 생각했습니다.
- 수정 기능의 경우, 기존에 존재하던 POST /terms/agreement 를 이용하면 된다고 생각했습니다
- 따라서 유저의 OPTIONAL한 Term에 대한 응답 목록을 조회하는 GET /terms/optional-answer 를 추가했습니다.
- [x] GET /terms/optional-answer API 구현
- [x] 로컬 테스트

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
