### PR TITLE
[UKET-199] 지인 기능 추가 

### DIFF
--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -12,10 +12,12 @@ import uket.api.user.response.ActiveEventsResponse
 import uket.api.user.response.EntryGroupListItemResponse
 import uket.api.user.response.EventDetailResponse
 import uket.api.user.response.EventRoundListItemResponse
+import uket.api.user.response.PerformerResponse
 import uket.api.user.response.ReservationInfoResponse
 import uket.common.response.ListResponse
 import uket.domain.admin.service.OrganizationService
 import uket.domain.uketevent.service.BannerService
+import uket.domain.uketevent.service.PerformerService
 import uket.domain.uketevent.service.UketEventRoundService
 import uket.domain.uketevent.service.UketEventService
 import uket.facade.UketEventFacade
@@ -29,6 +31,7 @@ class EventController(
     private val uketEventFacade: UketEventFacade,
     private val organizationService: OrganizationService,
     private val bannerService: BannerService,
+    private val performerService: PerformerService,
 ) {
     @Operation(summary = "활성화된 행사 목록 조회", description = "누구나 조회 가능한 행사 목록을 가져옵니다")
     @GetMapping("/uket-events")
@@ -101,5 +104,15 @@ class EventController(
 
         val response = ReservationInfoResponse.of(uketEvent, roundResponses)
         return ResponseEntity.ok(response)
+    }
+
+    @Operation(summary = "회차 출연자 목록 조회", description = "회차의 공연자 목록을 조회합니다.")
+    @GetMapping("/rounds/{id}/performers")
+    fun getPerformers(
+        @PathVariable("id") uketEventRoundId: Long,
+    ): ResponseEntity<ListResponse<PerformerResponse>> {
+        val performers = performerService.findAllByUketEventRoundId(uketEventRoundId)
+        val responses = performers.map { PerformerResponse.from(it) }
+        return ResponseEntity.ok(ListResponse(responses))
     }
 }

--- a/src/main/kotlin/uket/api/user/TicketController.kt
+++ b/src/main/kotlin/uket/api/user/TicketController.kt
@@ -41,7 +41,7 @@ class TicketController(
         request: TicketingRequest,
     ): ResponseEntity<TicketingResponse> {
         val now = LocalDateTime.now()
-        val tickets = ticketingFacade.ticketing(userId, request.entryGroupId, request.buyCount, request.friend, now)
+        val tickets = ticketingFacade.ticketing(userId, request.entryGroupId, request.buyCount, request.performerName, now)
         val entryGroup = entryGroupService.getById(request.entryGroupId)
         val event = uketEventService.getById(entryGroup.uketEventId)
         val payment = paymentService.getByOrganizationId(event.organizationId)

--- a/src/main/kotlin/uket/api/user/request/TicketingRequest.kt
+++ b/src/main/kotlin/uket/api/user/request/TicketingRequest.kt
@@ -3,5 +3,5 @@ package uket.api.user.request
 data class TicketingRequest(
     val entryGroupId: Long,
     val buyCount: Int,
-    val friend: String,
+    val performerName: String,
 )

--- a/src/main/kotlin/uket/api/user/response/PerformerResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/PerformerResponse.kt
@@ -1,0 +1,17 @@
+package uket.api.user.response
+
+import uket.domain.uketevent.entity.Performer
+
+data class PerformerResponse(
+    val performerId: Long,
+    val name: String,
+    val ticketCount: Int,
+) {
+    companion object {
+        fun from(performer: Performer): PerformerResponse = PerformerResponse(
+            performer.id,
+            performer.name,
+            performer.totalTicketCount
+        )
+    }
+}

--- a/src/main/kotlin/uket/domain/reservation/dto/CreateTicketCommand.kt
+++ b/src/main/kotlin/uket/domain/reservation/dto/CreateTicketCommand.kt
@@ -6,5 +6,5 @@ data class CreateTicketCommand(
     val userId: Long,
     val entryGroupId: Long,
     val ticketStatus: TicketStatus,
-    val friend: String,
+    val performerName: String,
 )

--- a/src/main/kotlin/uket/domain/reservation/entity/Ticket.kt
+++ b/src/main/kotlin/uket/domain/reservation/entity/Ticket.kt
@@ -17,6 +17,7 @@ class Ticket(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0L,
+    val performerName: String,
     val userId: Long,
     val entryGroupId: Long,
     @Enumerated(EnumType.STRING)

--- a/src/main/kotlin/uket/domain/reservation/repository/TicketJdbcRepository.kt
+++ b/src/main/kotlin/uket/domain/reservation/repository/TicketJdbcRepository.kt
@@ -13,8 +13,8 @@ class TicketJdbcRepository(
     fun saveAllBatch(tickets: List<Ticket>) {
         val sql =
             """
-                INSERT INTO ticket (user_id, entry_group_id, status, ticket_no, enter_at, created_at, updated_at, deleted_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO ticket (user_id, entry_group_id, status, performer_name, ticket_no, enter_at, created_at, updated_at, deleted_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """
 
         jdbcTemplate.batchUpdate(
@@ -25,11 +25,12 @@ class TicketJdbcRepository(
                     ps.setLong(1, ticket.userId)
                     ps.setLong(2, ticket.entryGroupId)
                     ps.setString(3, ticket.status.name)
-                    ps.setString(4, ticket.ticketNo)
-                    ps.setObject(5, ticket.enterAt)
-                    ps.setObject(6, ticket.createdAt)
-                    ps.setObject(7, ticket.updatedAt)
-                    ps.setObject(8, ticket.deletedAt)
+                    ps.setString(4, ticket.performerName)
+                    ps.setString(5, ticket.ticketNo)
+                    ps.setObject(6, ticket.enterAt)
+                    ps.setObject(7, ticket.createdAt)
+                    ps.setObject(8, ticket.updatedAt)
+                    ps.setObject(9, ticket.deletedAt)
                 }
 
                 override fun getBatchSize(): Int = tickets.size

--- a/src/main/kotlin/uket/domain/reservation/service/TicketService.kt
+++ b/src/main/kotlin/uket/domain/reservation/service/TicketService.kt
@@ -32,12 +32,14 @@ class TicketService(
 
     @Transactional
     fun publishTickets(createTicketCommand: CreateTicketCommand, count: Int): List<Ticket> {
+        println(createTicketCommand.performerName)
         val tickets = List(count) {
             Ticket(
                 userId = createTicketCommand.userId,
                 entryGroupId = createTicketCommand.entryGroupId,
                 status = createTicketCommand.ticketStatus,
                 ticketNo = UUID.randomUUID().toString(),
+                performerName = createTicketCommand.performerName,
                 enterAt = null,
             )
         }

--- a/src/main/kotlin/uket/domain/uketevent/entity/Performer.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/Performer.kt
@@ -1,0 +1,30 @@
+package uket.domain.uketevent.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+@Entity
+class Performer(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private val id: Long,
+
+    @ManyToOne
+    @JoinColumn(name = "uket_event_round_id")
+    private val uketEventRound: UketEventRound,
+
+    private val name: String,
+
+    private var totalTicketCount: Int,
+) {
+    fun addTicketCount(addCount: Int) {
+        totalTicketCount += addCount
+    }
+
+    fun minusTicketCount(minusCount: Int) {
+        totalTicketCount -= minusCount
+    }
+}

--- a/src/main/kotlin/uket/domain/uketevent/entity/Performer.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/Performer.kt
@@ -1,24 +1,22 @@
 package uket.domain.uketevent.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 
 @Entity
 class Performer(
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private val id: Long,
+    val id: Long,
 
-    @ManyToOne
-    @JoinColumn(name = "uket_event_round_id")
-    private val uketEventRound: UketEventRound,
+    @Column(name = "uket_event_round_id")
+    val uketEventRoundId: Long,
 
-    private val name: String,
+    val name: String,
 
-    private var totalTicketCount: Int,
+    var totalTicketCount: Int,
 ) {
     fun addTicketCount(addCount: Int) {
         totalTicketCount += addCount

--- a/src/main/kotlin/uket/domain/uketevent/repository/PerformerRepository.kt
+++ b/src/main/kotlin/uket/domain/uketevent/repository/PerformerRepository.kt
@@ -1,0 +1,6 @@
+package uket.domain.uketevent.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uket.domain.uketevent.entity.Performer
+
+interface PerformerRepository : JpaRepository<Performer, Long>

--- a/src/main/kotlin/uket/domain/uketevent/repository/PerformerRepository.kt
+++ b/src/main/kotlin/uket/domain/uketevent/repository/PerformerRepository.kt
@@ -3,4 +3,8 @@ package uket.domain.uketevent.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import uket.domain.uketevent.entity.Performer
 
-interface PerformerRepository : JpaRepository<Performer, Long>
+interface PerformerRepository : JpaRepository<Performer, Long> {
+    fun findAllByUketEventRoundId(uketEventRoundId: Long): List<Performer>
+
+    fun findByNameAndUketEventRoundId(name: String, uketEventRoundId: Long): Performer
+}

--- a/src/main/kotlin/uket/domain/uketevent/service/PerformerService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/PerformerService.kt
@@ -1,0 +1,31 @@
+package uket.domain.uketevent.service
+
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uket.domain.uketevent.entity.Performer
+import uket.domain.uketevent.repository.PerformerRepository
+
+@Service
+class PerformerService(
+    val performerRepository: PerformerRepository,
+) {
+    @Transactional(readOnly = true)
+    fun getById(id: Long): Performer {
+        val performer = performerRepository.findByIdOrNull(id)
+            ?: throw IllegalStateException("참여자를 찾을 수 없습니다.")
+        return performer
+    }
+
+    @Transactional
+    fun addTicketCountForPerformer(performerId: Long, ticketCount: Int) {
+        val performer = getById(performerId)
+        performer.addTicketCount(ticketCount)
+    }
+
+    @Transactional
+    fun minusTicketCountForPerformer(performerId: Long, ticketCount: Int) {
+        val performer = getById(performerId)
+        performer.minusTicketCount(ticketCount)
+    }
+}

--- a/src/main/kotlin/uket/domain/uketevent/service/PerformerService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/PerformerService.kt
@@ -28,4 +28,9 @@ class PerformerService(
         val performer = getById(performerId)
         performer.minusTicketCount(ticketCount)
     }
+
+    @Transactional(readOnly = true)
+    fun findAllByUketEventRoundId(roundId: Long): List<Performer> = performerRepository.findAllByUketEventRoundId(roundId)
+
+    fun findByNameAndRoundId(name: String, roundId: Long): Performer = performerRepository.findByNameAndUketEventRoundId(name, roundId)
 }

--- a/src/main/kotlin/uket/domain/uketevent/service/PerformerService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/PerformerService.kt
@@ -32,5 +32,6 @@ class PerformerService(
     @Transactional(readOnly = true)
     fun findAllByUketEventRoundId(roundId: Long): List<Performer> = performerRepository.findAllByUketEventRoundId(roundId)
 
+    @Transactional(readOnly = true)
     fun findByNameAndRoundId(name: String, roundId: Long): Performer = performerRepository.findByNameAndUketEventRoundId(name, roundId)
 }

--- a/src/main/kotlin/uket/facade/TicketingFacade.kt
+++ b/src/main/kotlin/uket/facade/TicketingFacade.kt
@@ -38,11 +38,12 @@ class TicketingFacade(
         val event = uketEventService.getById(eventRound.uketEventId)
         validateTicketingCount(user.id, eventRound.id, buyCount, event.buyTicketLimit)
 
+        entryGroupService.increaseReservedCount(entryGroup.id, buyCount)
+
         val performer = performerService.findByNameAndRoundId(pName, eventRound.id)
         // TODO 지인 별 인원 제한 존재 시 validation 추가 필요
         performerService.addTicketCountForPerformer(performer.id, buyCount)
 
-        entryGroupService.increaseReservedCount(entryGroup.id, buyCount)
         return ticketService.publishTickets(CreateTicketCommand(user.id, entryGroup.id, TicketStatus.BEFORE_PAYMENT, pName), buyCount)
     }
 

--- a/src/test/kotlin/uket/domain/reservation/TicketRepositoryTest.kt
+++ b/src/test/kotlin/uket/domain/reservation/TicketRepositoryTest.kt
@@ -74,6 +74,7 @@ class TicketRepositoryTest(
                 entryGroupId = entryGroup.id,
                 status = TicketStatus.BEFORE_ENTER,
                 ticketNo = "ticketA",
+                performerName = "홍길동",
                 enterAt = null,
             )
             entityManager.persist(ticket)

--- a/src/test/kotlin/uket/domain/uketEvent/UketEventFacadeTest.kt
+++ b/src/test/kotlin/uket/domain/uketEvent/UketEventFacadeTest.kt
@@ -18,9 +18,9 @@ class UketEventFacadeTest :
 
         isolationMode = IsolationMode.InstancePerLeaf
 
-        it("더미데이터 출력") {
-            createDummyData(100)
-        }
+//        it("더미데이터 출력") {
+//            createDummyData(100)
+//        }
     }) {
     companion object {
         fun createDummyData(count: Int) {


### PR DESCRIPTION
# 📌 개요
- 회차별 공연자 목록 조회 기능 추가(GET /rounds/{id}/performers)
- 예매 시, 공연자 이름을 입력 받아 이름별 티켓 개수 count

# 💻 작업사항
- 이전 행사처럼 단순히 공연자 이름만 예매 목록에 텍스트로 띄워줄 것이라면 Performer 엔티티 불필요.
- 다만, 추후에 공연자별 티켓수 제한 등의 로직이 필요할 것으로 생각되어(UketEvent나 Registration에서 공연자별 티켓 수 제한을 입력받고, ticketing 메서드에서 validation 진행하는 방식) 미리 틀을 만들어두고자 추가함.
- 구현의 단순성을 위해 이름만으로 식별이 가능(동명이인의 경우 악기, 학번 등의 정보를 괄호에 추가 ex. "홍길동(드럼)")하다고 가정하고 id를 거의 활용하지 않음. 추후에 기능이 더 복잡해진다면 수정 필요.
- [x] Performer 테이블 생성 및 회차별 공연자 전체 목록 조회 API 작성
- [x] Ticket 예매 시, 해당 회차의 performer의 티켓 예매 개수 증가

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 