### PR TITLE
[UKET-198] 티켓 예매 완료 시 알림톡 발송 추가

### DIFF
--- a/src/main/kotlin/uket/api/admin/AdminTicketController.kt
+++ b/src/main/kotlin/uket/api/admin/AdminTicketController.kt
@@ -68,7 +68,7 @@ class AdminTicketController(
         @PathVariable("ticketStatus") ticketStatus: TicketStatus,
     ): ResponseEntity<UpdateTicketStatusResponse> {
         val ticket: Ticket = ticketService.getById(ticketId)
-        val updatedTicket = updateTicketStatusFacade.updateTicketStatus(ticket.entryGroupId, ticketId, ticketStatus)
+        val updatedTicket = updateTicketStatusFacade.updateTicketStatus(ticket.entryGroupId, ticketId, ticketStatus, ticket.userId)
 
         val response = UpdateTicketStatusResponse.from(updatedTicket)
         return ResponseEntity.ok(response)

--- a/src/main/kotlin/uket/domain/reservation/service/TicketService.kt
+++ b/src/main/kotlin/uket/domain/reservation/service/TicketService.kt
@@ -12,6 +12,7 @@ import uket.domain.reservation.entity.Ticket
 import uket.domain.reservation.enums.TicketStatus
 import uket.domain.reservation.repository.TicketRepository
 import uket.uket.domain.reservation.repository.TicketJdbcRepository
+import uket.uket.modules.push.UserMessageTemplate
 import java.util.UUID
 
 @Service
@@ -26,9 +27,16 @@ class TicketService(
         return ticket
     }
 
-    fun findLiveEnterTickets(organizationId: Long, uketEventId: Long?, pageable: Pageable): Page<LiveEnterUserDto> = ticketRepository.findLiveEnterUserDtosByUketEventAndRoundId(organizationId, uketEventId, TicketStatus.FINISH_ENTER, pageable)
+    fun findLiveEnterTickets(organizationId: Long, uketEventId: Long?, pageable: Pageable): Page<LiveEnterUserDto> =
+        ticketRepository.findLiveEnterUserDtosByUketEventAndRoundId(
+            organizationId,
+            uketEventId,
+            TicketStatus.FINISH_ENTER,
+            pageable
+        )
 
-    fun searchAllTickets(organizationId: Long, uketEventId: Long?, pageable: Pageable): Page<TicketSearchDto> = ticketRepository.findAllByOrganizationId(organizationId, uketEventId, pageable)
+    fun searchAllTickets(organizationId: Long, uketEventId: Long?, pageable: Pageable): Page<TicketSearchDto> =
+        ticketRepository.findAllByOrganizationId(organizationId, uketEventId, pageable)
 
     @Transactional
     fun publishTickets(createTicketCommand: CreateTicketCommand, count: Int): List<Ticket> {
@@ -38,7 +46,7 @@ class TicketService(
                 userId = createTicketCommand.userId,
                 entryGroupId = createTicketCommand.entryGroupId,
                 status = createTicketCommand.ticketStatus,
-                ticketNo = UUID.randomUUID().toString(),
+                ticketNo = createTicketNo(),
                 performerName = createTicketCommand.performerName,
                 enterAt = null,
             )
@@ -48,6 +56,12 @@ class TicketService(
         val ticketNos = tickets.map { it.ticketNo }
         return ticketRepository.findByTicketNoIn(ticketNos)
     }
+
+    private fun createTicketNo() = UUID
+        .randomUUID()
+        .toString()
+        .replace("-", "")
+        .substring(0, UserMessageTemplate.TEMPLATE_MAXIMUM_LENGTH)
 
     @Transactional
     fun updateTicket(ticket: Ticket) {
@@ -109,7 +123,12 @@ class TicketService(
         }
     }
 
-    fun findAllActiveByUserAndEventRound(userId: Long, entryGroupId: Long): List<Ticket> = ticketRepository.findAllbyUserIdAndEventRoundIdAndStatusNot(userId, entryGroupId, TicketStatus.notActiveStatuses)
+    fun findAllActiveByUserAndEventRound(userId: Long, entryGroupId: Long): List<Ticket> =
+        ticketRepository.findAllbyUserIdAndEventRoundIdAndStatusNot(
+            userId,
+            entryGroupId,
+            TicketStatus.notActiveStatuses
+        )
 
     fun validateTicketOwner(userId: Long, ticketId: Long) {
         val ticket = this.getById(ticketId)

--- a/src/main/kotlin/uket/facade/PaymentInformationMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/PaymentInformationMessageSendService.kt
@@ -1,0 +1,40 @@
+package uket.facade
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import uket.common.enums.BankCode
+import uket.uket.modules.push.ReceiverType
+import uket.uket.modules.push.UserMessageSendEvent
+import uket.uket.modules.push.UserMessageTemplate
+
+@Service
+class PaymentInformationMessageSendService(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    fun send(
+        eventName: String,
+        ticketPrice: Int,
+        bankCode: BankCode,
+        accountNumber: String,
+        depositorName: String,
+        userName: String,
+        userPhoneNumber: String,
+    ) {
+        applicationEventPublisher
+            .publishEvent(
+                UserMessageSendEvent(
+                    templateCode = UserMessageTemplate.결제안내알림톡.code,
+                    command = UserMessageTemplate.결제안내알림톡.결제안내Command(
+                        eventName = eventName,
+                        ticketPrice = ticketPrice.toString(),
+                        bankName = bankCode.name,
+                        accountNumber = accountNumber,
+                        depositorName = depositorName,
+                        userName = userName
+                    ),
+                    receiverType = ReceiverType.PHONE_NUMBER,
+                    receiverKey = userPhoneNumber
+                )
+            )
+    }
+}

--- a/src/main/kotlin/uket/facade/PaymentInformationMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/PaymentInformationMessageSendService.kt
@@ -2,7 +2,7 @@ package uket.facade
 
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
-import uket.common.enums.BankCode
+import uket.domain.payment.entity.Payment
 import uket.uket.modules.push.ReceiverType
 import uket.uket.modules.push.UserMessageSendEvent
 import uket.uket.modules.push.UserMessageTemplate
@@ -13,10 +13,8 @@ class PaymentInformationMessageSendService(
 ) {
     fun send(
         eventName: String,
-        ticketPrice: Int,
-        bankCode: BankCode,
-        accountNumber: String,
-        depositorName: String,
+        ticketPrice: Long,
+        account: Payment.Account,
         userName: String,
         userPhoneNumber: String,
     ) {
@@ -27,9 +25,9 @@ class PaymentInformationMessageSendService(
                     command = UserMessageTemplate.결제안내알림톡.결제안내Command(
                         eventName = eventName,
                         ticketPrice = ticketPrice.toString(),
-                        bankName = bankCode.name,
-                        accountNumber = accountNumber,
-                        depositorName = depositorName,
+                        bankName = account.bankCode.name,
+                        accountNumber = account.accountNumber,
+                        depositorName = account.depositorName,
                         userName = userName
                     ),
                     receiverType = ReceiverType.PHONE_NUMBER,

--- a/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
@@ -1,4 +1,4 @@
-package uket.uket.facade
+package uket.facade
 
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -6,26 +6,42 @@ import uket.common.enums.EventType
 import uket.uket.modules.push.ReceiverType
 import uket.uket.modules.push.UserMessageSendEvent
 import uket.uket.modules.push.UserMessageTemplate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
 
 @Service
 class TicketingCompletionMessageSendService(
     private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
-    fun send(userName: String, userPhoneNumber: String, eventName: String, eventType: EventType, ticketNo: String, eventDate: String, eventLocation: String) {
-        applicationEventPublisher.publishEvent(
-            UserMessageSendEvent(
-                templateCode = UserMessageTemplate.예매완료알림톡.code,
-                command = UserMessageTemplate.예매완료알림톡.예매완료알림Command(
-                    userName = userName,
-                    eventName = eventName,
-                    eventType = eventType.krName,
-                    ticketNo = ticketNo,
-                    행사일시 = eventDate,
-                    행사장소 = eventLocation
-                ),
-                receiverType = ReceiverType.PHONE_NUMBER,
-                receiverKey = userPhoneNumber
+    fun send(
+        userName: String,
+        userPhoneNumber: String,
+        eventName: String,
+        eventType: EventType,
+        ticketNo: String,
+        eventDate: LocalDateTime,
+        eventLocation: String,
+    ) {
+        val formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일 HH시 mm분", Locale.KOREAN)
+        val dateString = eventDate
+            .format(formatter)
+
+        applicationEventPublisher
+            .publishEvent(
+                UserMessageSendEvent(
+                    templateCode = UserMessageTemplate.예매완료알림톡.code,
+                    command = UserMessageTemplate.예매완료알림톡.예매완료알림Command(
+                        userName = userName,
+                        eventName = eventName,
+                        eventType = eventType.krName,
+                        ticketNo = ticketNo,
+                        행사일시 = dateString,
+                        행사장소 = eventLocation
+                    ),
+                    receiverType = ReceiverType.PHONE_NUMBER,
+                    receiverKey = userPhoneNumber
+                )
             )
-        )
     }
 }

--- a/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
@@ -23,9 +23,12 @@ class TicketingCompletionMessageSendService(
         eventDate: LocalDateTime,
         eventLocation: String,
     ) {
-        val formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 E요일 HH시 mm분", Locale.KOREAN)
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일", Locale.KOREAN)
+        val timeFormatter = DateTimeFormatter.ofPattern("HH시 mm분", Locale.KOREAN)
         val dateString = eventDate
-            .format(formatter)
+            .format(dateFormatter)
+        val timeString = eventDate
+            .format(timeFormatter)
 
         applicationEventPublisher
             .publishEvent(
@@ -36,7 +39,8 @@ class TicketingCompletionMessageSendService(
                         eventName = eventName,
                         eventType = eventType.krName,
                         ticketNo = ticketNo,
-                        행사일시 = dateString,
+                        행사일자 = dateString,
+                        행사시간 = timeString,
                         행사장소 = eventLocation
                     ),
                     receiverType = ReceiverType.PHONE_NUMBER,

--- a/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
@@ -1,0 +1,31 @@
+package uket.uket.facade
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import uket.common.enums.EventType
+import uket.uket.modules.push.ReceiverType
+import uket.uket.modules.push.UserMessageSendEvent
+import uket.uket.modules.push.UserMessageTemplate
+
+@Service
+class TicketingCompletionMessageSendService(
+    private val applicationEventPublisher: ApplicationEventPublisher,
+) {
+    fun send(userName: String, userPhoneNumber: String, eventName: String, eventType: EventType, ticketNo: String, eventDate: String, eventLocation: String) {
+        applicationEventPublisher.publishEvent(
+            UserMessageSendEvent(
+                templateCode = UserMessageTemplate.예매완료알림톡.code,
+                command = UserMessageTemplate.예매완료알림톡.예매완료알림Command(
+                    userName = userName,
+                    eventName = eventName,
+                    eventType = eventType.krName,
+                    ticketNo = ticketNo,
+                    행사일시 = eventDate,
+                    행사장소 = eventLocation
+                ),
+                receiverType = ReceiverType.PHONE_NUMBER,
+                receiverKey = userPhoneNumber
+            )
+        )
+    }
+}

--- a/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/TicketingCompletionMessageSendService.kt
@@ -8,7 +8,7 @@ import uket.uket.modules.push.UserMessageSendEvent
 import uket.uket.modules.push.UserMessageTemplate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-import java.util.*
+import java.util.Locale
 
 @Service
 class TicketingCompletionMessageSendService(

--- a/src/main/kotlin/uket/facade/TicketingFacade.kt
+++ b/src/main/kotlin/uket/facade/TicketingFacade.kt
@@ -17,7 +17,6 @@ import uket.domain.uketevent.service.UketEventService
 import uket.domain.user.entity.User
 import uket.domain.user.service.UserService
 import uket.modules.redis.aop.DistributedLock
-import uket.uket.facade.TicketingCompletionMessageSendService
 import java.time.LocalDateTime
 
 @Service
@@ -78,7 +77,7 @@ class TicketingFacade(
             eventName = event.eventName,
             eventType = event.eventType,
             ticketNo = ticket.ticketNo,
-            eventDate = entryGroup.entryStartDateTime.toString(),
+            eventDate = entryGroup.entryStartDateTime,
             eventLocation = event.location
         )
     }

--- a/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
+++ b/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
@@ -8,7 +8,6 @@ import uket.domain.uketevent.service.EntryGroupService
 import uket.domain.uketevent.service.UketEventService
 import uket.domain.user.service.UserService
 import uket.modules.redis.aop.DistributedLock
-import uket.uket.facade.TicketingCompletionMessageSendService
 
 @Component
 class UpdateTicketStatusFacade(
@@ -35,7 +34,7 @@ class UpdateTicketStatusFacade(
                 eventName = event.eventName,
                 eventType = event.eventType,
                 ticketNo = ticket.ticketNo,
-                eventDate = entryGroup.entryStartDateTime.toString(),
+                eventDate = entryGroup.entryStartDateTime,
                 eventLocation = event.location
             )
         }

--- a/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
+++ b/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
@@ -5,17 +5,39 @@ import uket.domain.reservation.entity.Ticket
 import uket.domain.reservation.enums.TicketStatus
 import uket.domain.reservation.service.TicketService
 import uket.domain.uketevent.service.EntryGroupService
+import uket.domain.uketevent.service.UketEventService
+import uket.domain.user.service.UserService
 import uket.modules.redis.aop.DistributedLock
+import uket.uket.facade.TicketingCompletionMessageSendService
 
 @Component
 class UpdateTicketStatusFacade(
     private val ticketService: TicketService,
     private val entryGroupService: EntryGroupService,
+    private val ticketingCompletionMessageSendService: TicketingCompletionMessageSendService,
+    private val userService: UserService,
+    private val uketEventService: UketEventService,
 ) {
     @DistributedLock(key = "'ticketing' + #entryGroupId")
-    fun updateTicketStatus(entryGroupId: Long, ticketId: Long, ticketStatus: TicketStatus): Ticket {
+    fun updateTicketStatus(entryGroupId: Long, ticketId: Long, ticketStatus: TicketStatus, userId: Long): Ticket {
         if (ticketStatus === TicketStatus.RESERVATION_CANCEL) {
             entryGroupService.decreaseReservedCount(entryGroupId)
+        }
+        if (ticketStatus == TicketStatus.BEFORE_ENTER) {
+            val user = userService.getById(userId)
+            val entryGroup = entryGroupService.getById(entryGroupId)
+            val event = uketEventService.getById(entryGroup.uketEventId)
+            val ticket = ticketService.getById(ticketId)
+
+            ticketingCompletionMessageSendService.send(
+                userName = user.name,
+                userPhoneNumber = user.phoneNumber!!,
+                eventName = event.eventName,
+                eventType = event.eventType,
+                ticketNo = ticket.ticketNo,
+                eventDate = entryGroup.entryStartDateTime.toString(),
+                eventLocation = event.location
+            )
         }
         return ticketService.updateTicketStatus(ticketId, ticketStatus)
     }

--- a/src/main/kotlin/uket/facade/UserMessageSendExampleService.kt
+++ b/src/main/kotlin/uket/facade/UserMessageSendExampleService.kt
@@ -17,7 +17,7 @@ class UserMessageSendExampleService(
         applicationEventPublisher.publishEvent(
             UserMessageSendEvent(
                 templateCode = UserMessageTemplate.티켓취소알림톡.code,
-                command = UserMessageTemplate.티켓취소알림톡.티켓취소알림톡Command(
+                command = UserMessageTemplate.티켓취소알림톡.티켓취소알림Command(
                     userName = "홍길동",
                     eventName = "소리터",
                     organizationName = "소리터",
@@ -34,7 +34,7 @@ class UserMessageSendExampleService(
         applicationEventPublisher.publishEvent(
             UserMessageBulkSendEvent(
                 templateCode = UserMessageTemplate.티켓취소알림톡.code,
-                command = UserMessageTemplate.티켓취소알림톡.티켓취소알림톡Command(
+                command = UserMessageTemplate.티켓취소알림톡.티켓취소알림Command(
                     userName = "홍길동",
                     eventName = "소리터",
                     organizationName = "소리터",

--- a/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
+++ b/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
@@ -17,21 +17,19 @@ sealed class UserMessageTemplate(
     ) {
         private const val 예매내역목록_LINK_PATH = "ticket-list"
 
-        override fun makeContext(command: Command): Map<String, String> {
-            return with(command as 관람일당일안내Command) {
-                mapOf(
-                    "이름" to userName,
-                    "행사명" to eventName,
-                    "행사타입" to eventType,
-                    "행사일시" to 행사일시,
-                    "행사장소" to 행사장소,
-                    "예매번호" to ticketNo,
-                    LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
-                )
-            }
+        override fun makeContext(command: Command): Map<String, String> = with(command as 예매완료알림Command) {
+            mapOf(
+                "이름" to userName,
+                "행사명" to eventName,
+                "행사타입" to eventType,
+                "행사일시" to 행사일시,
+                "행사장소" to 행사장소,
+                "예매번호" to ticketNo,
+                LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
+            )
         }
 
-        data class 관람일당일안내Command(
+        data class 예매완료알림Command(
             val userName: String,
             val eventName: String,
             val eventType: String,
@@ -47,17 +45,15 @@ sealed class UserMessageTemplate(
     ) {
         private const val 예매내역목록_LINK_PATH = "ticket-list"
 
-        override fun makeContext(command: Command): Map<String, String> {
-            return with(command as 관람일당일안내Command) {
-                mapOf(
-                    "이름" to userName,
-                    "행사명" to eventName,
-                    "행사타입" to eventType,
-                    "행사일시" to 행사일시,
-                    "행사장소" to 행사장소,
-                    LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
-                )
-            }
+        override fun makeContext(command: Command): Map<String, String> = with(command as 관람일당일안내Command) {
+            mapOf(
+                "이름" to userName,
+                "행사명" to eventName,
+                "행사타입" to eventType,
+                "행사일시" to 행사일시,
+                "행사장소" to 행사장소,
+                LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
+            )
         }
 
         data class 관람일당일안내Command(
@@ -75,20 +71,18 @@ sealed class UserMessageTemplate(
     ) {
         private const val 예매내역목록_LINK_PATH = "ticket-list"
 
-        override fun makeContext(command: Command): Map<String, String> {
-            return with(command as 관람일당일안내Command) {
-                mapOf(
-                    "이름" to userName,
-                    "행사명" to eventName,
-                    "행사타입" to eventType,
-                    "행사일시" to 행사일시,
-                    "행사장소" to 행사장소,
-                    LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
-                )
-            }
+        override fun makeContext(command: Command): Map<String, String> = with(command as 관람일하루전안내Command) {
+            mapOf(
+                "이름" to userName,
+                "행사명" to eventName,
+                "행사타입" to eventType,
+                "행사일시" to 행사일시,
+                "행사장소" to 행사장소,
+                LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
+            )
         }
 
-        data class 관람일당일안내Command(
+        data class 관람일하루전안내Command(
             val userName: String,
             val eventName: String,
             val eventType: String,
@@ -101,19 +95,17 @@ sealed class UserMessageTemplate(
         code = "uket_ticket_cancel",
         referrer = REFERRER_TICKET_CANCEL
     ) {
-        override fun makeContext(command: Command): Map<String, String> {
-            return with(command as 티켓취소알림톡Command) {
-                mapOf(
-                    "이름" to userName,
-                    "행사명" to eventName,
-                    "주최명" to organizationName,
-                    "행사타입" to eventType,
-                    "예매번호" to 예매번호
-                )
-            }
+        override fun makeContext(command: Command): Map<String, String> = with(command as 티켓취소알림Command) {
+            mapOf(
+                "이름" to userName,
+                "행사명" to eventName,
+                "주최명" to organizationName,
+                "행사타입" to eventType,
+                "예매번호" to 예매번호
+            )
         }
 
-        data class 티켓취소알림톡Command(
+        data class 티켓취소알림Command(
             val userName: String,
             val eventName: String,
             val organizationName: String,

--- a/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
+++ b/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
@@ -22,7 +22,8 @@ sealed class UserMessageTemplate(
                 "이름" to userName,
                 "행사명" to eventName,
                 "행사타입" to eventType,
-                "행사일시" to 행사일시,
+                "행사일자" to 행사일자,
+                "행사시간" to 행사시간,
                 "행사장소" to 행사장소,
                 "예매번호" to ticketNo,
                 LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
@@ -34,7 +35,8 @@ sealed class UserMessageTemplate(
             val eventName: String,
             val eventType: String,
             val ticketNo: String,
-            val 행사일시: String,
+            val 행사일자: String,
+            val 행사시간: String,
             val 행사장소: String,
         ) : Command
     }
@@ -150,5 +152,7 @@ sealed class UserMessageTemplate(
         private const val REFERRER_EVENT_TODAY = "3x0jJanU"
         private const val REFERRER_TICKET_PAID = "RqqcPBKL"
         private const val REFERRER_TICKET_PAYMENT = "JwuAfMZC"
+
+        const val TEMPLATE_MAXIMUM_LENGTH = 14
     }
 }

--- a/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
+++ b/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
@@ -13,7 +13,7 @@ sealed class UserMessageTemplate(
 
     data object 예매완료알림톡 : UserMessageTemplate(
         code = "uket_ticket_paid",
-        referrer = REFERRER_TICLET_PAID
+        referrer = REFERRER_TICKET_PAID
     ) {
         private const val 예매내역목록_LINK_PATH = "ticket-list"
 
@@ -36,6 +36,34 @@ sealed class UserMessageTemplate(
             val ticketNo: String,
             val 행사일시: String,
             val 행사장소: String,
+        ) : Command
+    }
+
+    data object 결제안내알림톡 : UserMessageTemplate(
+        code = "uket_ticket_payment",
+        referrer = REFERRER_TICKET_PAYMENT
+    ) {
+        private const val 예매내역목록_LINK_PATH = "ticket-list"
+
+        override fun makeContext(command: Command): Map<String, String> = with(command as 결제안내Command) {
+            mapOf(
+                "행사명" to eventName,
+                "금액" to ticketPrice,
+                "은행이름" to bankName,
+                "계좌번호" to accountNumber,
+                "예금주" to depositorName,
+                "이름" to userName,
+                LINK_CONTEXT_KEY to 예매내역목록_LINK_PATH
+            )
+        }
+
+        data class 결제안내Command(
+            val eventName: String,
+            val ticketPrice: String,
+            val bankName: String,
+            val accountNumber: String,
+            val depositorName: String,
+            val userName: String,
         ) : Command
     }
 
@@ -120,6 +148,7 @@ sealed class UserMessageTemplate(
         private const val REFERRER_TICKET_CANCEL = "NK3MiV1n"
         private const val REFERRER_EVENT_REMIND = "WjsTGIUz"
         private const val REFERRER_EVENT_TODAY = "3x0jJanU"
-        private const val REFERRER_TICLET_PAID = "RqqcPBKL"
+        private const val REFERRER_TICKET_PAID = "RqqcPBKL"
+        private const val REFERRER_TICKET_PAYMENT = "JwuAfMZC"
     }
 }


### PR DESCRIPTION
# 📌 개요
- 티켓 예매 완료 시(무료인 경우 예매 직후, 유료인 경우 admin이 예매 완료 상태로 변경한 이후), 알림톡 발송 기능 추가

# 💻 작업사항
- [x] 알림톡 발송 작업물 이용해 기능 추가
- 테스트 결과(키가 없어서 톡이 실제로 오는지는 확인하지 못했습니다)
<img width="1367" alt="스크린샷 2025-06-22 17 02 14" src="https://github.com/user-attachments/assets/aaa18819-7613-4d7c-9c98-de5e97f45256" />
<img width="1129" alt="스크린샷 2025-06-22 17 02 20" src="https://github.com/user-attachments/assets/f90a2096-a6c1-44d7-98ee-093dbc327e32" />
 
# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- updateTicketStatusFacade.updateTicketStatus에서 후처리?를 담당하는 것으로 알고 있는데, 현재 실행되는 시점에 따르면 전처리인 상태입니다.
- 이 상황에서 같은 상태로의 변경 요청이 들어오면(ex. 이미 취소 상태인데, 또 취소 요청) 전처리 로직이 여러번 실행되는 문제가 있을 수 있습니다.
- 후처리 형태로(티켓 상태가 같은지 여부를 확인 후, 로직 실행) 변경하려고 하는데, [이게 직전에 추가되었던 부분](https://github.com/DCNJ-Uket/Uket-BE-Kotlin/pull/91)이라 혹시 추가 의견이 있는지 궁금합니다!

=> 가장 이상적으로는 EventRegistration처럼 상태 변경에 대한 관리를 세부적으로 해줘야 함(allowedPrevStatuses) by 영준
