### PR TITLE
[UKET-202] 행사 목록 조회 오류 수정

### DIFF
--- a/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
@@ -109,7 +109,8 @@ class UketEvent(
     }
 
     fun finish(now: LocalDateTime = LocalDateTime.now()) {
-        this.isVisible = false
+//        this.isVisible = false
+//        TODO 추후에 행사가 많아서 비어보이지 않으면 적용
         this.eventFinishDateTime = now
     }
 }

--- a/src/main/kotlin/uket/domain/uketevent/repository/UketEventRepository.kt
+++ b/src/main/kotlin/uket/domain/uketevent/repository/UketEventRepository.kt
@@ -2,8 +2,8 @@ package uket.domain.uketevent.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import uket.common.enums.EventType
 import uket.domain.uketevent.entity.UketEvent
-import java.time.LocalDateTime
 
 interface UketEventRepository : JpaRepository<UketEvent, Long> {
     @Query(
@@ -30,27 +30,9 @@ interface UketEventRepository : JpaRepository<UketEvent, Long> {
     @Query(
         """
             SELECT ue FROM UketEvent ue
-            WHERE ue.lastRoundDateTime >= :date
+            WHERE ue.isVisible = true AND ue.eventType IN :eventTypes
             order by ue.firstRoundDateTime
         """
     )
-    fun findAllByLastRoundDateAfterOrderByFirstRoundDateTime(date: LocalDateTime): List<UketEvent>
-
-    @Query(
-        """
-            SELECT ue FROM UketEvent ue
-            WHERE ue.lastRoundDateTime >= :date AND ue.eventType = "FESTIVAL"
-            order by ue.firstRoundDateTime
-        """
-    )
-    fun findAllFestivalByLastRoundDateAfterOrderByFirstRoundDateTime(date: LocalDateTime): List<UketEvent>
-
-    @Query(
-        """
-            SELECT ue FROM UketEvent ue
-            WHERE ue.lastRoundDateTime >= :date AND ue.eventType = "PERFORMANCE"
-            order by ue.firstRoundDateTime
-        """
-    )
-    fun findAllPerformanceByLastRoundDateAfterOrderByFirstRoundDateTime(date: LocalDateTime): List<UketEvent>
+    fun findAllVisibleInEventTypesOrderByFirstRoundDateTime(eventTypes: List<EventType>): List<UketEvent>
 }

--- a/src/main/kotlin/uket/domain/uketevent/service/UketEventService.kt
+++ b/src/main/kotlin/uket/domain/uketevent/service/UketEventService.kt
@@ -4,10 +4,9 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uket.api.admin.dto.EventNameDto
+import uket.common.enums.EventType
 import uket.domain.uketevent.entity.UketEvent
 import uket.domain.uketevent.repository.UketEventRepository
-import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @Service
 class UketEventService(
@@ -34,16 +33,8 @@ class UketEventService(
     }
 
     @Transactional(readOnly = true)
-    fun findAllNowActiveOrdered(at: LocalDateTime): List<UketEvent> =
-        uketEventRepository.findAllByLastRoundDateAfterOrderByFirstRoundDateTime(at.truncatedTo(ChronoUnit.DAYS))
-
-    @Transactional(readOnly = true)
-    fun findAllNowActiveOrderedFestival(at: LocalDateTime): List<UketEvent> =
-        uketEventRepository.findAllFestivalByLastRoundDateAfterOrderByFirstRoundDateTime(at.truncatedTo(ChronoUnit.DAYS))
-
-    @Transactional(readOnly = true)
-    fun findAllNowActiveOrderedPerformance(at: LocalDateTime): List<UketEvent> =
-        uketEventRepository.findAllPerformanceByLastRoundDateAfterOrderByFirstRoundDateTime(at.truncatedTo(ChronoUnit.DAYS))
+    fun findAllVisibleOrderedEventByEventTypes(eventTypes: List<EventType>): List<UketEvent> =
+        uketEventRepository.findAllVisibleInEventTypesOrderByFirstRoundDateTime(eventTypes)
 
     @Transactional
     fun deleteById(id: Long) {
@@ -51,9 +42,7 @@ class UketEventService(
     }
 
     @Transactional
-    fun save(uketEvent: UketEvent): UketEvent {
-        return uketEventRepository.save(uketEvent)
-    }
+    fun save(uketEvent: UketEvent): UketEvent = uketEventRepository.save(uketEvent)
 
     @Transactional
     fun init(uketEventId: Long): UketEvent {

--- a/src/main/kotlin/uket/facade/UketEventFacade.kt
+++ b/src/main/kotlin/uket/facade/UketEventFacade.kt
@@ -2,6 +2,7 @@ package uket.facade
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uket.common.enums.EventType
 import uket.domain.uketevent.dto.EventListItem
 import uket.domain.uketevent.entity.EntryGroup
 import uket.domain.uketevent.entity.UketEventRound
@@ -40,11 +41,12 @@ class UketEventFacade(
 
     @Transactional(readOnly = true)
     fun getNowActiveEventItemList(type: String, at: LocalDateTime): List<EventListItem> {
-        val activeOrderedEvents = when (type) {
-            "FESTIVAL" -> uketEventService.findAllNowActiveOrderedFestival(at)
-            "PERFORMANCE" -> uketEventService.findAllNowActiveOrderedPerformance(at)
-            else -> uketEventService.findAllNowActiveOrdered(at)
+        val eventTypes = when (type) {
+            "FESTIVAL" -> listOf(EventType.FESTIVAL)
+            "PERFORMANCE" -> listOf(EventType.PERFORMANCE)
+            else -> listOf(EventType.PERFORMANCE, EventType.PERFORMANCE)
         }
+        val activeOrderedEvents = uketEventService.findAllVisibleOrderedEventByEventTypes(eventTypes)
 
         val activeEventIds = activeOrderedEvents.map { it.id }
         val roundsMap = uketEventRoundService.getEventRoundsMapByEventIds(activeEventIds)


### PR DESCRIPTION
# 📌 개요
- 기존 행사 목록 조회 시, first/last round datetime을 기준으로 active를 결정했던 부분을 isVisible을 기준으로 결정하도록 수정했습니다.

# 💻 작업사항
- [x] active event 조회 기준 변경
- [x] UketEvent.finish()에서 isVisible을 변경하지 않도록 수정
<img width="825" alt="image" src="https://github.com/user-attachments/assets/4a4b24ad-06dc-4222-80dd-e77253fc0d59" /> 

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
