### PR TITLE
hotfix: 무료 은행코드 추가

### DIFF
--- a/src/main/kotlin/uket/common/enums/BankCode.kt
+++ b/src/main/kotlin/uket/common/enums/BankCode.kt
@@ -1,6 +1,7 @@
 package uket.common.enums
 
 enum class BankCode(val code: String) {
+    무료("000"),
     한국은행("001"),
     산업은행("002"),
     기업은행("003"),


### PR DESCRIPTION
# 📌 개요
- 행사 자체가 무료일 경우 bankCode가 null인 것을 막기 위해 무료 관련 은행코드를 추가했습니다.

# 💻 작업사항
- [x] BankCode enums 무료 은행코드 추가

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
