### PR TITLE
[UKET-228] 슈퍼 관리자 계정 내 전체 행사 목록 조회 분기 처리

### DIFF
--- a/src/main/kotlin/uket/api/admin/EventRegistrationController.kt
+++ b/src/main/kotlin/uket/api/admin/EventRegistrationController.kt
@@ -108,10 +108,14 @@ class EventRegistrationController(
         val pageRequest = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.DESC, "createdAt"))
         val admin = adminService.getByIdWithOrganization(adminId)
 
-        val uketEventRegistrationSummaryResponse = eventRegistrationService.findAllByOrganizationId(admin.organization.id, pageRequest).map {
-            UketEventRegistrationSummaryResponse.from(it)
+        val registrations = if (admin.isSuperAdmin) {
+            eventRegistrationService.findAll(pageRequest)
+        } else {
+            eventRegistrationService.findAllByOrganizationId(admin.organization.id, pageRequest)
         }
-        return CustomPageResponse(uketEventRegistrationSummaryResponse)
+
+        val summaryResponse = registrations.map { UketEventRegistrationSummaryResponse.from(it) }
+        return CustomPageResponse(summaryResponse)
     }
 
     @SecurityRequirement(name = "JWT")

--- a/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
+++ b/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
@@ -29,6 +29,11 @@ class EventRegistrationService(
     }
 
     @Transactional(readOnly = true)
+    fun findAll(pageable: Pageable): Page<EventRegistration> {
+        return eventRegistrationRepository.findAll(pageable)
+    }
+
+    @Transactional(readOnly = true)
     fun getByIdWithEventRoundAndEntryGroup(id: Long): EventRegistration {
         val eventRegistration = getById(id)
 


### PR DESCRIPTION
# 📌 개요
- 슈퍼 관리자 계정 내 전체 행사 목록 조회 분기 처리를 진행 해 전체 행사가 조회 가능하도록 했습니다.

# 💻 작업사항
- [x] 슈퍼 관리자 계정 내 전체 행사 목록 조회 분기 처리

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
