### PR TITLE
[UKET-229] 티켓 예매 시, 공연자(지인)가 없는 경우 처리

### DIFF
--- a/src/main/kotlin/uket/facade/TicketingFacade.kt
+++ b/src/main/kotlin/uket/facade/TicketingFacade.kt
@@ -46,9 +46,11 @@ class TicketingFacade(
 
         entryGroupService.increaseReservedCount(entryGroup.id, buyCount)
 
-        val performer = performerService.findByNameAndRoundId(pName, eventRound.id)
-        // TODO 지인 별 인원 제한 존재 시 validation 추가 필요
-        performerService.addTicketCountForPerformer(performer.id, buyCount)
+        if (pName.isNotEmpty()) {
+            val performer = performerService.findByNameAndRoundId(pName, eventRound.id)
+            // TODO 지인 별 인원 제한 존재 시 validation 추가 필요
+            performerService.addTicketCountForPerformer(performer.id, buyCount)
+        }
 
         val tickets = ticketService.publishTickets(
             createTicketCommand = CreateTicketCommand(

--- a/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
+++ b/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
@@ -24,10 +24,7 @@ class UpdateTicketStatusFacade(
         if (ticketStatus === TicketStatus.RESERVATION_CANCEL) {
             entryGroupService.decreaseReservedCount(entryGroupId)
 
-            val ticket = ticketService.getById(ticketId)
-            val entryGroup = entryGroupService.getById(entryGroupId)
-            val performer = performerService.findByNameAndRoundId(ticket.performerName, entryGroup.uketEventRoundId)
-            performerService.minusTicketCountForPerformer(performer.id, 1);
+            reduceTicketCountForPerformer(ticketId, entryGroupId)
         }
         if (ticketStatus == TicketStatus.BEFORE_ENTER) {
             val user = userService.getById(userId)
@@ -46,5 +43,14 @@ class UpdateTicketStatusFacade(
             )
         }
         return ticketService.updateTicketStatus(ticketId, ticketStatus)
+    }
+
+    private fun reduceTicketCountForPerformer(ticketId: Long, entryGroupId: Long) {
+        val ticket = ticketService.getById(ticketId)
+        if (ticket.performerName.isNotEmpty()) {
+            val entryGroup = entryGroupService.getById(entryGroupId)
+            val performer = performerService.findByNameAndRoundId(ticket.performerName, entryGroup.uketEventRoundId)
+            performerService.minusTicketCountForPerformer(performer.id, 1);
+        }
     }
 }

--- a/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
+++ b/src/main/kotlin/uket/facade/UpdateTicketStatusFacade.kt
@@ -5,6 +5,7 @@ import uket.domain.reservation.entity.Ticket
 import uket.domain.reservation.enums.TicketStatus
 import uket.domain.reservation.service.TicketService
 import uket.domain.uketevent.service.EntryGroupService
+import uket.domain.uketevent.service.PerformerService
 import uket.domain.uketevent.service.UketEventService
 import uket.domain.user.service.UserService
 import uket.modules.redis.aop.DistributedLock
@@ -16,11 +17,17 @@ class UpdateTicketStatusFacade(
     private val ticketingCompletionMessageSendService: TicketingCompletionMessageSendService,
     private val userService: UserService,
     private val uketEventService: UketEventService,
+    private val performerService: PerformerService,
 ) {
     @DistributedLock(key = "'ticketing' + #entryGroupId")
     fun updateTicketStatus(entryGroupId: Long, ticketId: Long, ticketStatus: TicketStatus, userId: Long): Ticket {
         if (ticketStatus === TicketStatus.RESERVATION_CANCEL) {
             entryGroupService.decreaseReservedCount(entryGroupId)
+
+            val ticket = ticketService.getById(ticketId)
+            val entryGroup = entryGroupService.getById(entryGroupId)
+            val performer = performerService.findByNameAndRoundId(ticket.performerName, entryGroup.uketEventRoundId)
+            performerService.minusTicketCountForPerformer(performer.id, 1);
         }
         if (ticketStatus == TicketStatus.BEFORE_ENTER) {
             val user = userService.getById(userId)


### PR DESCRIPTION
# 📌 개요
- 티켓 예매 시, 공연자가 없는 경우를 추가했습니다.

# 💻 작업사항
- [x] String.isEmpty() 즉, ""일 때 공연자 별 ticket 개수 조정을 하지 않도록 처리

# ❌ 주의사항
- AdminTicket에서 updateTicketStatus의 상세 조정이 필요합니다. eventRegistration처럼 StatusStatue를 이용할 필요가 있어보입니다.

# 💡 코드 리뷰 요청사항
- 
