### PR TITLE
[UKET-219] Organization이 아닌, Event 별로 Payment가 존재하도록 수정

### DIFF
--- a/src/main/kotlin/uket/api/user/TicketController.kt
+++ b/src/main/kotlin/uket/api/user/TicketController.kt
@@ -44,7 +44,7 @@ class TicketController(
         val tickets = ticketingFacade.ticketing(userId, request.entryGroupId, request.buyCount, request.performerName, now)
         val entryGroup = entryGroupService.getById(request.entryGroupId)
         val event = uketEventService.getById(entryGroup.uketEventId)
-        val payment = paymentService.getByOrganizationId(event.organizationId)
+        val payment = paymentService.getById(event.paymentId)
 
         return ResponseEntity.ok(
             TicketingResponse(

--- a/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
+++ b/src/main/kotlin/uket/domain/eventregistration/service/EventRegistrationService.kt
@@ -9,24 +9,22 @@ import org.springframework.transaction.annotation.Transactional
 import uket.common.PublicException
 import uket.domain.eventregistration.entity.EventRegistration
 import uket.domain.eventregistration.entity.EventRegistrationStatus
+import uket.domain.uketevent.repository.UketEventRepository
 
 @Service
 class EventRegistrationService(
     val eventRegistrationRepository: EventRegistrationRepository,
+    private val uketEventRepository: UketEventRepository,
 ) {
     @Transactional(readOnly = true)
-    fun findById(id: Long): EventRegistration? {
-        return eventRegistrationRepository.findByIdOrNull(id)
-    }
+    fun findById(id: Long): EventRegistration? = eventRegistrationRepository.findByIdOrNull(id)
 
     @Transactional(readOnly = true)
     fun getById(id: Long): EventRegistration = findById(id)
         ?: throw IllegalArgumentException("[EventRegistrationService] EventRegistration을 조회할 수 없습니다. | eventRegistrationId: $id")
 
     @Transactional(readOnly = true)
-    fun findAllByOrganizationId(organizationId: Long, pageable: Pageable): Page<EventRegistration> {
-        return eventRegistrationRepository.findAllByOrganizationId(organizationId, pageable)
-    }
+    fun findAllByOrganizationId(organizationId: Long, pageable: Pageable): Page<EventRegistration> = eventRegistrationRepository.findAllByOrganizationId(organizationId, pageable)
 
     @Transactional(readOnly = true)
     fun getByIdWithEventRoundAndEntryGroup(id: Long): EventRegistration {
@@ -40,9 +38,7 @@ class EventRegistrationService(
     }
 
     @Transactional
-    fun registerEvent(eventRegistration: EventRegistration): EventRegistration {
-        return eventRegistrationRepository.save(eventRegistration)
-    }
+    fun registerEvent(eventRegistration: EventRegistration): EventRegistration = eventRegistrationRepository.save(eventRegistration)
 
     @Transactional
     fun updateEventRegistration(originalEventRegistrationId: Long, updatedEventRegistration: EventRegistration): EventRegistration {
@@ -86,5 +82,13 @@ class EventRegistrationService(
         val eventRegistration = eventRegistrationRepository.findByUketEventId(uketEventId)
 
         eventRegistration?.clearUketEvent()
+    }
+
+    @Transactional
+    fun settingPayment(eventRegistrationId: Long, paymentId: Long): EventRegistration {
+        val eventRegistration = getById(eventRegistrationId)
+        eventRegistration.settingPayment(paymentId)
+
+        return eventRegistrationRepository.save(eventRegistration)
     }
 }

--- a/src/main/kotlin/uket/domain/payment/repository/PaymentRepository.kt
+++ b/src/main/kotlin/uket/domain/payment/repository/PaymentRepository.kt
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import uket.domain.payment.entity.Payment
 
 interface PaymentRepository : JpaRepository<Payment, Long> {
-    fun findByOrganizationId(organizationId: Long): Payment?
+    fun findByOrganizationId(organizationId: Long): List<Payment>
 }

--- a/src/main/kotlin/uket/domain/payment/service/PaymentService.kt
+++ b/src/main/kotlin/uket/domain/payment/service/PaymentService.kt
@@ -19,12 +19,14 @@ class PaymentService(
     }
 
     @Transactional(readOnly = true)
-    fun getByOrganizationId(organizationId: Long): Payment {
+    fun getByOrganizationId(organizationId: Long): List<Payment> {
         val payment = paymentRepository.findByOrganizationId(organizationId)
-            ?: throw PublicNotFoundException(
+        if (payment.isEmpty()) {
+            throw PublicNotFoundException(
                 publicMessage = "결제 정보를 찾을 수 없습니다",
                 systemMessage = "[PaymentService] Organization 의 결제정보를 찾을 수 없습니다. | organizationId: $organizationId"
             )
+        }
         return payment
     }
 

--- a/src/main/kotlin/uket/domain/payment/service/PaymentService.kt
+++ b/src/main/kotlin/uket/domain/payment/service/PaymentService.kt
@@ -14,7 +14,10 @@ class PaymentService(
     @Transactional(readOnly = true)
     fun getById(paymentId: Long): Payment {
         val payment = paymentRepository.findByIdOrNull(paymentId)
-            ?: throw IllegalStateException("해당 결제 정보를 찾을 수 없습니다")
+            ?: throw PublicNotFoundException(
+                publicMessage = "결제 정보를 찾을 수 없습니다",
+                systemMessage = "[PaymentService] 해당 결제정보를 찾을 수 없습니다. | paymentId: $paymentId"
+            )
         return payment
     }
 

--- a/src/main/kotlin/uket/domain/payment/service/PaymentService.kt
+++ b/src/main/kotlin/uket/domain/payment/service/PaymentService.kt
@@ -27,4 +27,7 @@ class PaymentService(
             )
         return payment
     }
+
+    @Transactional
+    fun save(payment: Payment): Payment = paymentRepository.save(payment)
 }

--- a/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
+++ b/src/main/kotlin/uket/domain/uketevent/entity/UketEvent.kt
@@ -31,6 +31,9 @@ class UketEvent(
     @Column(name = "organization_id")
     val organizationId: Long,
 
+    @Column(name = "payment_id")
+    val paymentId: Long,
+
     @Column(name = "event_name")
     val eventName: String,
 

--- a/src/main/kotlin/uket/facade/CreateUketEventFacade.kt
+++ b/src/main/kotlin/uket/facade/CreateUketEventFacade.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 import uket.domain.eventregistration.entity.EventRegistrationStatus
 import uket.domain.eventregistration.service.EventRegistrationService
+import uket.domain.payment.service.PaymentService
 import uket.domain.uketevent.service.BannerService
 import uket.domain.uketevent.service.EntryGroupService
 import uket.domain.uketevent.service.UketEventRoundService
@@ -16,6 +17,7 @@ class CreateUketEventFacade(
     private val entryGroupService: EntryGroupService,
     private val bannerService: BannerService,
     private val eventRegistrationService: EventRegistrationService,
+    private val paymentService: PaymentService,
 ) {
     @Transactional
     fun invoke(eventRegistrationId: Long) {
@@ -24,8 +26,14 @@ class CreateUketEventFacade(
             "[CreateUketEventFacade] 검수 진행 상태가 아닌데 UketEvent를 생성할 수 없습니다. | eventRegistrationId: ${eventRegistration.id}"
         }
 
-        val savedUketEvent = uketEventService.save(eventRegistration.toUketEvent())
-        val savedEventRegistration = eventRegistrationService.settingEvent(
+        val savedPayment = paymentService.save(eventRegistration.toPayment())
+        var savedEventRegistration = eventRegistrationService.settingPayment(
+            eventRegistrationId = eventRegistrationId,
+            paymentId = savedPayment.id
+        )
+
+        val savedUketEvent = uketEventService.save(savedEventRegistration.toUketEvent())
+        savedEventRegistration = eventRegistrationService.settingEvent(
             eventRegistrationId = eventRegistrationId,
             uketEventId = savedUketEvent.id
         )

--- a/src/main/kotlin/uket/facade/EventPaymentInfoFacade.kt
+++ b/src/main/kotlin/uket/facade/EventPaymentInfoFacade.kt
@@ -12,7 +12,7 @@ class EventPaymentInfoFacade(
 ) {
     fun getEventPaymentInfoWithTicketPrice(uketEventId: Long): PaymentWithTicketPriceResult {
         val uketEvent = uketEventService.getById(uketEventId)
-        val payment = paymentService.getByOrganizationId(uketEvent.organizationId)
+        val payment = paymentService.getById(uketEvent.paymentId)
 
         return PaymentWithTicketPriceResult(
             payment = payment,


### PR DESCRIPTION
# 📌 개요
- Organization 별로 Payment 존재 -> Event 별로 Payment 존재

# 💻 작업사항
- [x] UketEvent에 PaymentId 추가
- [x] EventRegistration의 상태 변경 과정에 Payment 생성 기능 추가
- [x] Payment 조회 시, UketEvent.organizationId가 아닌 UketEvent.paymentId를 이용하도록 변경

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
