### PR TITLE
[UKET-234] 서버 - DB - 사용자 간 시간대 오류 수정

### DIFF
--- a/.github/workflows/uket-dev-cd.yml
+++ b/.github/workflows/uket-dev-cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - fix/UKET-234
 
 env:
   DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}

--- a/.github/workflows/uket-dev-cd.yml
+++ b/.github/workflows/uket-dev-cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - fix/UKET-234
 
 env:
   DOCKER_REGISTRY_URL: ${{ secrets.DOCKER_REGISTRY_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM openjdk:21-slim-buster AS Builder
 WORKDIR /usr/bin/app
 COPY build/libs/*.jar app.jar
 ENV TZ=Asia/Seoul
-RUN ["java", "-Djarmode=layertools", "-Dspring.profiles.active=dev", "-Duser.timezone=Asia/Seoul" ,"-jar", "app.jar", "extract"]
+RUN ["java", "-Djarmode=layertools", "-Dspring.profiles.active=dev", "-Duser.timezone=$TZ" ,"-jar", "app.jar", "extract"]
 
 FROM openjdk:21-slim-buster AS runner
 ARG WORK_DIR=/usr/bin/app
 WORKDIR ${WORK_DIR}
+ENV TZ=Asia/Seoul
 
 COPY --from=builder ${WORK_DIR}/dependencies/ ./
 COPY --from=builder ${WORK_DIR}/spring-boot-loader/ ./
@@ -24,6 +25,6 @@ RUN chmod +x /usr/bin/run-java.sh
 ENV JAVA_MAIN_CLASS org.springframework.boot.loader.launch.JarLauncher
 ENV JAVA_APP_DIR /usr/bin/app
 ENV JAVA_LIB_DIR /usr/bin/app
-ENV JAVA_OPTIONS "-ea -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+ExitOnOutOfMemoryError"
+ENV JAVA_OPTIONS "-ea -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:+ExitOnOutOfMemoryError -Duser.timezone=$TZ"
 
 ENTRYPOINT [ "sh", "/usr/bin/run-java.sh" ]

--- a/src/main/kotlin/uket/auth/DevController.kt
+++ b/src/main/kotlin/uket/auth/DevController.kt
@@ -18,4 +18,28 @@ class DevController(
         )
         return newAccessToken
     }
+
+    @GetMapping("/timezone")
+    fun checkTime(): Map<String, String> {
+        // 1. JVM의 기본 시간대 정보 출력
+        val jvmDefaultZone = java.util.TimeZone
+            .getDefault()
+            .id
+
+        // 2. LocalDateTime.now()가 어떤 값을 생성하는지 확인
+        val localDateTimeNow = java.time.LocalDateTime
+            .now()
+            .toString()
+
+        // 3. ZonedDateTime.now()가 어떤 값을 생성하는지 확인
+        val zonedDateTimeNow = java.time.ZonedDateTime
+            .now()
+            .toString()
+
+        return mapOf(
+            "jvm.default.timezone" to jvmDefaultZone,
+            "LocalDateTime.now()" to localDateTimeNow,
+            "ZonedDateTime.now()" to zonedDateTimeNow
+        )
+    }
 }


### PR DESCRIPTION
# 📌 개요
- 서버 - DB - 사용자 간 시간대 오류를 수정했습니다.

# 💻 작업사항
- [x] JVM, DB 모두 KST를 기준으로 하도록 설정했습니다
- [x] 이벤트 등록, 티켓 예매 및 조회 시 시간대에 문제가 없음을 확인 

# ❌ 주의사항
- 최초의 오류는 아래와  같았습니다
JVM -> UTC
DB -> UTC
jdbc url 옵션 -> UTC+9

1. 사용자가 티켓을 예매합니다 -> 시스템이 LocalDateTime.now()로 시간을 생성합니다(7/15 15:00, 실제 시간은 7/15 06:00)
2. 시스템이 DB에 시간을 저장합니다. (7/15 15:00)
3. DB에서 시스템이 티켓 시간을 조회해 LocalDateTime로 가져옵니다. 이때 시간이 9시간이 빠집니다 (7/15 06:00)

저장할 때 
LocalDateTime이라 UTC 정보가 없고, datetime 컬럼인 경우에 
JVM과 DB의 시간대 차이를 적용해 변환해 저장할 것이라고 예상했으나
[그대로 저장하는 동작이라고 합니다.](https://dev.mysql.com/doc/connector-j/en/connector-j-time-instants.html#:~:text=it%20does%20not%20represent%20an%20instant%20and%2C%20when%20no%20time%20zone%20offset%20is%20specified%2C%20there%20is%20no%20time%20zone%20conversion%20for%20DATETIME%20values%2C%20so%20they%20are%20stored%20and%20retrieved%20as%20they%20are)

[불러올 때는 datetime이어도 변환될 수 있다고 합니다.
](https://dev.mysql.com/doc/connector-j/en/connector-j-time-instants.html#:~:text=When%20storing%20a,time.OffsetDateTime.)

- jdbc url 옵션을 제거하고, JVM과 DB를 UTC+9로 설정해서 해결했습니다.

# 💡 코드 리뷰 요청사항
- 
