### PR TITLE
[UKET-243] 행사 조회 시, 티켓팅 시작/종료 날짜 추가 & lastRoundDateTime 오류 수정

### DIFF
--- a/src/main/kotlin/uket/api/user/EventController.kt
+++ b/src/main/kotlin/uket/api/user/EventController.kt
@@ -49,6 +49,10 @@ class EventController(
         @PathVariable("id") eventId: Long,
     ): ResponseEntity<EventDetailResponse> {
         val event = uketEventService.getDetailById(eventId)
+        val rounds = uketEventRoundService.getEventRoundsByEventId(eventId)
+        check(rounds.size > 0) {
+            throw IllegalStateException("해당 행사의 회차가 없습니다.")
+        }
         val organization = organizationService.getById(event.organizationId)
         val banners = bannerService.findAllByUketEventId(event.id)
         val ticketingStatus = uketEventFacade.getCurrentEventTicketingStatus(eventId, LocalDateTime.now())
@@ -56,6 +60,7 @@ class EventController(
         return ResponseEntity.ok(
             EventDetailResponse.of(
                 uketEvent = event,
+                uketEventRound = rounds.get(0),
                 organization = organization,
                 banners = banners,
                 ticketingStatus = ticketingStatus

--- a/src/main/kotlin/uket/api/user/response/EventDetailResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/EventDetailResponse.kt
@@ -4,6 +4,7 @@ import uket.common.enums.EventType
 import uket.domain.admin.entity.Organization
 import uket.domain.uketevent.entity.Banner
 import uket.domain.uketevent.entity.UketEvent
+import uket.domain.uketevent.entity.UketEventRound
 import uket.domain.uketevent.enums.TicketingStatus
 import java.time.LocalDateTime
 
@@ -13,6 +14,8 @@ data class EventDetailResponse(
     val eventType: EventType,
     val firstRoundStartDateTime: LocalDateTime,
     val lastRoundStartDateTime: LocalDateTime,
+    val ticketingStartDateTime: LocalDateTime,
+    val ticketingEndDateTime: LocalDateTime,
     val information: String,
     val detailImageId: String,
     val banners: List<EventDetailBannerDto>,
@@ -37,6 +40,7 @@ data class EventDetailResponse(
     companion object {
         fun of(
             uketEvent: UketEvent,
+            uketEventRound: UketEventRound,
             organization: Organization,
             banners: List<Banner>,
             ticketingStatus: TicketingStatus,
@@ -46,6 +50,8 @@ data class EventDetailResponse(
             eventType = uketEvent.eventType,
             firstRoundStartDateTime = uketEvent.firstRoundDateTime,
             lastRoundStartDateTime = uketEvent.lastRoundDateTime,
+            ticketingStartDateTime = uketEventRound.ticketingStartDateTime,
+            ticketingEndDateTime = uketEventRound.ticketingEndDateTime,
             location = uketEvent.location,
             banners = banners.map { EventDetailBannerDto.from(it) },
             information = uketEvent.details.information,

--- a/src/main/kotlin/uket/api/user/response/EventDetailResponse.kt
+++ b/src/main/kotlin/uket/api/user/response/EventDetailResponse.kt
@@ -45,7 +45,7 @@ data class EventDetailResponse(
             eventName = uketEvent.eventName,
             eventType = uketEvent.eventType,
             firstRoundStartDateTime = uketEvent.firstRoundDateTime,
-            lastRoundStartDateTime = uketEvent.firstRoundDateTime,
+            lastRoundStartDateTime = uketEvent.lastRoundDateTime,
             location = uketEvent.location,
             banners = banners.map { EventDetailBannerDto.from(it) },
             information = uketEvent.details.information,


### PR DESCRIPTION
# 📌 개요
- 행사 조회 시, 티켓팅 시작/종료 날짜 추가하고 lastRoundDateTime이 firstRoundDateTime과 동일하게 나오는 오류를 수정했습니다.

# 💻 작업사항
- [x] 행사 조회 시, 티켓팅 시작/종료 날짜 추가
- [x] lastRoundDateTime이 firstRoundDateTime과 동일하게 나오는 오류를 수정

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
