### PR TITLE
[UKET-263] 입금대기중 상태에서 티켓 취소 시, 다른 템플릿의 알림톡 발송 기능 추가

### DIFF
--- a/src/main/kotlin/uket/facade/CancelTicketFacade.kt
+++ b/src/main/kotlin/uket/facade/CancelTicketFacade.kt
@@ -55,10 +55,10 @@ class CancelTicketFacade(
     private fun sendKakaoAlimtalk(
         ticket: Ticket,
         event: UketEvent,
-        userId: Long
+        userId: Long,
     ) {
         println(ticket.status)
-        when(ticket.status) {
+        when (ticket.status) {
             TicketStatus.REFUND_REQUESTED -> sendTicketCancelMessage(event, ticket, userId)
             TicketStatus.RESERVATION_CANCEL -> sendTicketCancel2Message(event, ticket, userId)
             else -> {}

--- a/src/main/kotlin/uket/facade/CancelTicketFacade.kt
+++ b/src/main/kotlin/uket/facade/CancelTicketFacade.kt
@@ -14,17 +14,19 @@ import uket.domain.uketevent.service.PerformerService
 import uket.domain.uketevent.service.UketEventRoundService
 import uket.domain.uketevent.service.UketEventService
 import uket.domain.user.service.UserService
-import uket.facade.message.TicketCancelMessageSendService
+import uket.facade.messNage.TicketCancelMessageSendService
+import uket.facade.message.TicketCancel2MessageSendService
 import java.time.LocalDateTime
 
 @Service
 class CancelTicketFacade(
-    val ticketService: TicketService,
-    val entryGroupService: EntryGroupService,
-    val uketEventRoundService: UketEventRoundService,
-    val uketEventService: UketEventService,
-    val performerService: PerformerService,
+    private val ticketService: TicketService,
+    private val entryGroupService: EntryGroupService,
+    private val uketEventRoundService: UketEventRoundService,
+    private val uketEventService: UketEventService,
+    private val performerService: PerformerService,
     private val ticketCancelMessageSendService: TicketCancelMessageSendService,
+    private val ticketCancel2MessageSendService: TicketCancel2MessageSendService,
     private val userService: UserService,
     private val organizationService: OrganizationService,
 ) {
@@ -45,11 +47,22 @@ class CancelTicketFacade(
         entryGroup.decreaseReservedCount();
         reducePerformerTicketCount(ticket, eventRound)
 
-        if (ticket.status == TicketStatus.REFUND_REQUESTED) {
-            sendTicketCancelMessage(event, ticket, userId)
-        }
+        sendKakaoAlimtalk(ticket, event, userId)
 
         return ticket
+    }
+
+    private fun sendKakaoAlimtalk(
+        ticket: Ticket,
+        event: UketEvent,
+        userId: Long
+    ) {
+        println(ticket.status)
+        when(ticket.status) {
+            TicketStatus.REFUND_REQUESTED -> sendTicketCancelMessage(event, ticket, userId)
+            TicketStatus.RESERVATION_CANCEL -> sendTicketCancel2Message(event, ticket, userId)
+            else -> {}
+        }
     }
 
     private fun sendTicketCancelMessage(
@@ -66,6 +79,21 @@ class CancelTicketFacade(
             event.eventType,
             ticket.ticketNo,
             organization.name
+        )
+    }
+
+    private fun sendTicketCancel2Message(
+        event: UketEvent,
+        ticket: Ticket,
+        userId: Long,
+    ) {
+        val user = userService.getById(userId)
+        ticketCancel2MessageSendService.send(
+            user.name,
+            event.eventType,
+            event.eventName,
+            ticket.ticketNo,
+            user.phoneNumber!!,
         )
     }
 

--- a/src/main/kotlin/uket/facade/message/TicketCancel2MessageSendService.kt
+++ b/src/main/kotlin/uket/facade/message/TicketCancel2MessageSendService.kt
@@ -9,9 +9,8 @@ import uket.uket.modules.push.UserMessageTemplate
 
 @Component
 class TicketCancel2MessageSendService(
-    private val applicationEventPublisher: ApplicationEventPublisher
+    private val applicationEventPublisher: ApplicationEventPublisher,
 ) {
-
     fun send(
         userName: String,
         eventType: EventType,
@@ -33,5 +32,4 @@ class TicketCancel2MessageSendService(
             )
         )
     }
-
 }

--- a/src/main/kotlin/uket/facade/message/TicketCancel2MessageSendService.kt
+++ b/src/main/kotlin/uket/facade/message/TicketCancel2MessageSendService.kt
@@ -1,0 +1,37 @@
+package uket.facade.message
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import uket.common.enums.EventType
+import uket.uket.modules.push.ReceiverType
+import uket.uket.modules.push.UserMessageSendEvent
+import uket.uket.modules.push.UserMessageTemplate
+
+@Component
+class TicketCancel2MessageSendService(
+    private val applicationEventPublisher: ApplicationEventPublisher
+) {
+
+    fun send(
+        userName: String,
+        eventType: EventType,
+        eventName: String,
+        예매번호: String,
+        userPhoneNumber: String,
+    ) {
+        applicationEventPublisher.publishEvent(
+            UserMessageSendEvent(
+                templateCode = UserMessageTemplate.티켓취소알림톡_입금대기중.code,
+                command = UserMessageTemplate.티켓취소알림톡_입금대기중.티켓취소알림_입금대기중Command(
+                    userName = userName,
+                    eventType = eventType.krName,
+                    eventName = eventName,
+                    예매번호 = 예매번호
+                ),
+                receiverType = ReceiverType.PHONE_NUMBER,
+                receiverKey = userPhoneNumber,
+            )
+        )
+    }
+
+}

--- a/src/main/kotlin/uket/facade/message/TicketCancelMessageSendService.kt
+++ b/src/main/kotlin/uket/facade/message/TicketCancelMessageSendService.kt
@@ -1,4 +1,4 @@
-package uket.facade.message
+package uket.facade.messNage
 
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
@@ -22,8 +22,8 @@ class TicketCancelMessageSendService(
         applicationEventPublisher
             .publishEvent(
                 UserMessageSendEvent(
-                    templateCode = UserMessageTemplate.티켓취소알림톡.code,
-                    command = UserMessageTemplate.티켓취소알림톡.티켓취소알림Command(
+                    templateCode = UserMessageTemplate.티켓취소알림톡_예매완료.code,
+                    command = UserMessageTemplate.티켓취소알림톡_예매완료.티켓취소알림_예매완료Command(
                         userName = userName,
                         eventName = eventName,
                         eventType = eventType.krName,

--- a/src/main/kotlin/uket/facade/message/UserMessageSendExampleService.kt
+++ b/src/main/kotlin/uket/facade/message/UserMessageSendExampleService.kt
@@ -16,8 +16,8 @@ class UserMessageSendExampleService(
     fun send() {
         applicationEventPublisher.publishEvent(
             UserMessageSendEvent(
-                templateCode = UserMessageTemplate.티켓취소알림톡.code,
-                command = UserMessageTemplate.티켓취소알림톡.티켓취소알림Command(
+                templateCode = UserMessageTemplate.티켓취소알림톡_예매완료.code,
+                command = UserMessageTemplate.티켓취소알림톡_예매완료.티켓취소알림_예매완료Command(
                     userName = "홍길동",
                     eventName = "소리터",
                     organizationName = "소리터",
@@ -33,8 +33,8 @@ class UserMessageSendExampleService(
     fun sendBulk() {
         applicationEventPublisher.publishEvent(
             UserMessageBulkSendEvent(
-                templateCode = UserMessageTemplate.티켓취소알림톡.code,
-                command = UserMessageTemplate.티켓취소알림톡.티켓취소알림Command(
+                templateCode = UserMessageTemplate.티켓취소알림톡_예매완료.code,
+                command = UserMessageTemplate.티켓취소알림톡_예매완료.티켓취소알림_예매완료Command(
                     userName = "홍길동",
                     eventName = "소리터",
                     organizationName = "소리터",

--- a/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
+++ b/src/main/kotlin/uket/modules/push/UserMessageTemplate.kt
@@ -71,11 +71,11 @@ sealed class UserMessageTemplate(
         ) : Command
     }
 
-    data object 티켓취소알림톡 : UserMessageTemplate(
+    data object 티켓취소알림톡_예매완료 : UserMessageTemplate(
         code = "uket_ticket_cancel",
         referrer = REFERRER_TICKET_CANCEL
     ) {
-        override fun makeContext(command: Command): Map<String, String> = with(command as 티켓취소알림Command) {
+        override fun makeContext(command: Command): Map<String, String> = with(command as 티켓취소알림_예매완료Command) {
             mapOf(
                 "이름" to userName,
                 "행사명" to eventName,
@@ -85,11 +85,32 @@ sealed class UserMessageTemplate(
             )
         }
 
-        data class 티켓취소알림Command(
+        data class 티켓취소알림_예매완료Command(
             val userName: String,
             val eventName: String,
             val organizationName: String,
             val eventType: String,
+            val 예매번호: String,
+        ) : Command
+    }
+
+    data object 티켓취소알림톡_입금대기중 : UserMessageTemplate(
+        code = "uket_ticket_cancel_2",
+        referrer = REFERRER_TICKET_CANCEL2
+    ) {
+        override fun makeContext(command: Command): Map<String, String> = with(command as 티켓취소알림_입금대기중Command) {
+            mapOf(
+                "이름" to userName,
+                "행사명" to eventName,
+                "행사타입" to eventType,
+                "예매번호" to 예매번호
+            )
+        }
+
+        data class 티켓취소알림_입금대기중Command(
+            val userName: String,
+            val eventType: String,
+            val eventName: String,
             val 예매번호: String,
         ) : Command
     }
@@ -150,6 +171,7 @@ sealed class UserMessageTemplate(
         private const val LINK_CONTEXT_KEY = "link"
 
         private const val REFERRER_TICKET_CANCEL = "NK3MiV1n"
+        private const val REFERRER_TICKET_CANCEL2 = "vvHO3wmQ"
         private const val REFERRER_EVENT_REMIND = "WjsTGIUz"
         private const val REFERRER_EVENT_TODAY = "3x0jJanU"
         private const val REFERRER_TICKET_PAID = "RqqcPBKL"


### PR DESCRIPTION
# 📌 개요
- 기존 예매 완료 상태에서 티켓 취소 시, 환불 관련 알림톡 발송만 존재하던 상황에서
- 입금 대기중 상태에서 티켓 취소 시, 티켓 취소 관련 알림톡 발송 기능 추가

# 💻 작업사항
- [x] 티켓 취소 알림톡 발송 기능 추가(환불 x)
- <img width="360" height="800" alt="image" src="https://github.com/user-attachments/assets/ac8adcfa-0976-4848-85a8-3a61713d0a7a" />

# ❌ 주의사항
- 

# 💡 코드 리뷰 요청사항
- 
